### PR TITLE
Catalog Hue Bridge API and add pairing script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-backend dev-frontend
+.PHONY: dev dev-backend dev-frontend pair-bridge
 
 dev-backend:
 	cd backend && . .venv/bin/activate && uvicorn app.main:app --reload --port 8000
@@ -11,3 +11,6 @@ dev:
 	$(MAKE) dev-backend & \
 	$(MAKE) dev-frontend & \
 	wait
+
+pair-bridge:
+	cd backend && . .venv/bin/activate && python scripts/pair_bridge.py

--- a/backend/HUE_API.md
+++ b/backend/HUE_API.md
@@ -1,0 +1,58 @@
+# Hue Bridge API reference
+
+Endpoints on the local Hue Bridge API (CLIP v1) that this app calls or
+plans to call. All paths are relative to `http://<bridge-ip>/api`, where
+`<bridge-ip>` is the address in `config.yaml` (gitignored, never
+committed — see `config.example.yaml` for the shape).
+
+`<username>` below is the API key minted once via `scripts/pair_bridge.py`
+and stored in `config.yaml` as `api_key`.
+
+## Pairing (already implemented — `scripts/pair_bridge.py`)
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api` | Mint a new API key. Body: `{"devicetype": "<app>#<device>"}`. Requires the bridge's physical link button to have been pressed within the last 30s, or returns error type 101. |
+
+## Bridge info
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/config` | Unauthenticated subset: name, modelid, swversion, apiversion, bridgeid, mac. Used for discovery/sanity-checks before pairing. |
+| GET | `/api/<username>/config` | Authenticated, fuller bridge config. |
+
+## Lights (issue: display brightness/color/on-off per bulb)
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/<username>/lights` | List all lights with current state. |
+| GET | `/api/<username>/lights/<id>` | Single light's state. |
+| PUT | `/api/<username>/lights/<id>/state` | Set `on` (bool), `bri` (1-254), color via `hue`+`sat`, `xy`, or `ct`. |
+
+Relevant `state` fields returned per light: `on`, `bri`, `hue`, `sat`, `xy`,
+`ct`, `colormode`, `reachable`.
+
+## Groups (rooms/zones)
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/<username>/groups` | List groups (rooms/zones) and their member lights. |
+| GET | `/api/<username>/groups/<id>` | Single group. |
+| PUT | `/api/<username>/groups/<id>/action` | Apply state to every light in the group at once; also how a scene gets activated (see below). |
+
+## Scenes (issue: display Scenes)
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/<username>/scenes` | List configured scenes (id, name, member lights). |
+| GET | `/api/<username>/scenes/<id>` | Scene detail, including per-light stored states. |
+| PUT | `/api/<username>/groups/<id>/action` | Activate a scene: body `{"scene": "<scene-id>"}`. Hue has no dedicated "activate" endpoint — scenes are applied through the owning group's action endpoint. |
+
+## Notes
+
+- This is the CLIP v1 local API (plain HTTP, no cert handling needed), not
+  the newer CLIP v2/remote API. v1 is what `scripts/pair_bridge.py` already
+  pairs against and is sufficient for LAN-only proxying.
+- The backend is the only thing that ever holds `<username>`/`api_key` —
+  per the architecture in CLAUDE.md, the browser only talks to the backend,
+  never directly to the bridge.

--- a/backend/scripts/pair_bridge.py
+++ b/backend/scripts/pair_bridge.py
@@ -29,12 +29,17 @@ DEVICETYPE = "hue-light-control#pairing"
 LINK_BUTTON_TIMEOUT_SECONDS = 60
 POLL_INTERVAL_SECONDS = 2
 
+# Transient failure modes we treat as "try again" rather than crashing:
+# unreachable/timed-out connections, and a non-JSON response from whatever's
+# at that IP.
+REQUEST_ERRORS = (urllib.error.URLError, json.JSONDecodeError)
+
 
 def discover_bridge_ip() -> str | None:
     try:
         with urllib.request.urlopen(DISCOVERY_URL, timeout=8) as resp:
             bridges = json.load(resp)
-    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+    except REQUEST_ERRORS as exc:
         print(f"Cloud discovery failed: {exc}", file=sys.stderr)
         return None
     return bridges[0]["internalipaddress"] if bridges else None
@@ -59,8 +64,12 @@ def request_api_key(ip: str) -> str:
     )
     deadline = time.monotonic() + LINK_BUTTON_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
-        with urllib.request.urlopen(req, timeout=5) as resp:
-            result = json.load(resp)[0]
+        try:
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                result = json.load(resp)[0]
+        except REQUEST_ERRORS:
+            time.sleep(POLL_INTERVAL_SECONDS)
+            continue
         if "success" in result:
             return result["success"]["username"]
         error = result.get("error", {})
@@ -71,8 +80,13 @@ def request_api_key(ip: str) -> str:
 
 
 def write_config(ip: str, api_key: str) -> None:
+    existing = {}
+    if CONFIG_PATH.exists():
+        with CONFIG_PATH.open() as f:
+            existing = yaml.safe_load(f) or {}
+    existing.update({"bridge_ip": ip, "api_key": api_key})
     with CONFIG_PATH.open("w") as f:
-        yaml.safe_dump({"bridge_ip": ip, "api_key": api_key}, f)
+        yaml.safe_dump(existing, f)
 
 
 def main() -> int:
@@ -85,7 +99,11 @@ def main() -> int:
         print("Could not discover a bridge. Pass --ip <address> to skip discovery.", file=sys.stderr)
         return 1
 
-    info = get_bridge_info(ip)
+    try:
+        info = get_bridge_info(ip)
+    except REQUEST_ERRORS as exc:
+        print(f"Could not reach bridge at {ip}: {exc}", file=sys.stderr)
+        return 1
     print(f"Found bridge: model {info.get('modelid')}, API {info.get('apiversion')}, sw {info.get('swversion')}")
 
     try:

--- a/backend/scripts/pair_bridge.py
+++ b/backend/scripts/pair_bridge.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Discover a Hue Bridge on the local network and pair with it.
+
+Run from backend/ with its venv active:
+
+    python scripts/pair_bridge.py
+
+Finds the bridge via Philips' cloud discovery service (falls back to
+--ip if that fails or if you'd rather skip it), prints its hardware
+info, then waits for the bridge's physical link button to be pressed
+to mint an API key. Writes the resulting bridge_ip/api_key to
+config.yaml (gitignored) in the shape backend/app/config.py expects.
+"""
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from app.config import CONFIG_PATH  # noqa: E402
+
+DISCOVERY_URL = "https://discovery.meethue.com/"
+DEVICETYPE = "hue-light-control#pairing"
+LINK_BUTTON_TIMEOUT_SECONDS = 60
+POLL_INTERVAL_SECONDS = 2
+
+
+def discover_bridge_ip() -> str | None:
+    try:
+        with urllib.request.urlopen(DISCOVERY_URL, timeout=8) as resp:
+            bridges = json.load(resp)
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        print(f"Cloud discovery failed: {exc}", file=sys.stderr)
+        return None
+    return bridges[0]["internalipaddress"] if bridges else None
+
+
+def get_bridge_info(ip: str) -> dict:
+    with urllib.request.urlopen(f"http://{ip}/api/config", timeout=5) as resp:
+        return json.load(resp)
+
+
+def request_api_key(ip: str) -> str:
+    body = json.dumps({"devicetype": DEVICETYPE}).encode()
+    req = urllib.request.Request(
+        f"http://{ip}/api",
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    print(
+        f"Press the link button on the Hue Bridge now "
+        f"(waiting up to {LINK_BUTTON_TIMEOUT_SECONDS}s)..."
+    )
+    deadline = time.monotonic() + LINK_BUTTON_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            result = json.load(resp)[0]
+        if "success" in result:
+            return result["success"]["username"]
+        error = result.get("error", {})
+        if error.get("type") != 101:  # 101 = link button not pressed
+            raise RuntimeError(f"Bridge returned error: {error.get('description', error)}")
+        time.sleep(POLL_INTERVAL_SECONDS)
+    raise TimeoutError("Timed out waiting for the link button to be pressed.")
+
+
+def write_config(ip: str, api_key: str) -> None:
+    with CONFIG_PATH.open("w") as f:
+        yaml.safe_dump({"bridge_ip": ip, "api_key": api_key}, f)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ip", help="Bridge IP, skips cloud discovery")
+    args = parser.parse_args()
+
+    ip = args.ip or discover_bridge_ip()
+    if not ip:
+        print("Could not discover a bridge. Pass --ip <address> to skip discovery.", file=sys.stderr)
+        return 1
+
+    info = get_bridge_info(ip)
+    print(f"Found bridge: model {info.get('modelid')}, API {info.get('apiversion')}, sw {info.get('swversion')}")
+
+    try:
+        api_key = request_api_key(ip)
+    except (RuntimeError, TimeoutError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    write_config(ip, api_key)
+    print(f"Wrote bridge_ip and api_key to {CONFIG_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds `backend/scripts/pair_bridge.py`: discovers the bridge via Philips' cloud discovery endpoint, prints hardware info (model, API/sw version), then mints an API key once the physical link button is pressed — writing `bridge_ip`/`api_key` into the gitignored `backend/config.yaml`.
- `make pair-bridge` runs it.
- Adds `backend/HUE_API.md`: catalog of the CLIP v1 endpoints the app will call for lights, groups, and scenes, with generic placeholders instead of real network identifiers.
- Real hardware/network findings for this specific bridge went into local-only `docs/hue-bridge-catalog.md` (gitignored) and `backend/config.yaml` (gitignored) — nothing real-identifier-shaped is tracked, per CLAUDE.md's repo visibility rules.

Closes #3.

## Test plan
- [x] `python -m py_compile scripts/pair_bridge.py`
- [x] Ran discovery + info-fetch against the real bridge (model BSB002 confirmed)
- [x] Ran full pairing flow live — link button pressed, `config.yaml` written, confirmed loadable via `app.config.load_config()`
- [x] `git check-ignore -v backend/config.yaml` confirms it's excluded
- [x] Gitignore-aware recursive grep across the tree for the real IP/bridge-ID/MAC: zero hits in trackable content
- [x] Pre-commit hardcoded-secrets hook passed