### PR TITLE
Display brightness, color, and on/off status per bulb

### DIFF
--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -1,0 +1,126 @@
+import colorsys
+import math
+from typing import Optional
+
+import httpx
+from pydantic import BaseModel
+
+from app.config import BridgeConfig
+
+
+class BridgeNotConfigured(Exception):
+    pass
+
+
+class BridgeUnreachable(Exception):
+    pass
+
+
+class Light(BaseModel):
+    id: str
+    name: str
+    on: bool
+    brightness_pct: int
+    color: Optional[str] = None
+    reachable: bool
+
+
+def _to_hex(r: float, g: float, b: float) -> str:
+    return "#{:02x}{:02x}{:02x}".format(round(r * 255), round(g * 255), round(b * 255))
+
+
+def _xy_to_rgb_hex(x: float, y: float) -> str:
+    """Philips' documented xyY -> sRGB conversion, at full brightness.
+
+    Brightness is reported separately (brightness_pct), so this always
+    renders the pure hue rather than a dimmed swatch.
+    """
+    z = 1.0 - x - y
+    X = x / y if y > 0 else 0.0
+    Z = z / y if y > 0 else 0.0
+
+    r = X * 1.656492 - 0.354851 - Z * 0.255038
+    g = -X * 0.707196 + 1.655397 + Z * 0.036152
+    b = X * 0.051713 - 0.121364 + Z * 1.011530
+
+    def gamma(c: float) -> float:
+        c = max(0.0, c)
+        c = 12.92 * c if c <= 0.0031308 else 1.055 * (c ** (1 / 2.4)) - 0.055
+        return max(0.0, min(1.0, c))
+
+    r, g, b = gamma(r), gamma(g), gamma(b)
+    maxc = max(r, g, b, 1e-6)
+    return _to_hex(r / maxc, g / maxc, b / maxc)
+
+
+def _hs_to_rgb_hex(hue: int, sat: int) -> str:
+    h = (hue % 65536) / 65535
+    s = sat / 254
+    r, g, b = colorsys.hsv_to_rgb(h, s, 1.0)
+    return _to_hex(r, g, b)
+
+
+def _ct_to_rgb_hex(mired: int) -> str:
+    """Mired color temperature -> approximate RGB (Tanner Helland's fit)."""
+    temp = (1_000_000 / mired) / 100
+    if temp <= 66:
+        r = 255.0
+        g = 99.47 * math.log(temp) - 161.12 if temp > 0 else 0.0
+    else:
+        r = 329.7 * ((temp - 60) ** -0.133)
+        g = 288.12 * ((temp - 60) ** -0.0755)
+    if temp >= 66:
+        b = 255.0
+    elif temp <= 19:
+        b = 0.0
+    else:
+        b = 138.52 * math.log(temp - 10) - 305.04
+
+    def clamp(v: float) -> int:
+        return max(0, min(255, round(v)))
+
+    return "#{:02x}{:02x}{:02x}".format(clamp(r), clamp(g), clamp(b))
+
+
+def _light_color(state: dict) -> Optional[str]:
+    mode = state.get("colormode")
+    if mode == "xy" and "xy" in state:
+        x, y = state["xy"]
+        return _xy_to_rgb_hex(x, y)
+    if mode == "hs" and "hue" in state and "sat" in state:
+        return _hs_to_rgb_hex(state["hue"], state["sat"])
+    if mode == "ct" and "ct" in state:
+        return _ct_to_rgb_hex(state["ct"])
+    return None
+
+
+def _to_light(light_id: str, raw: dict) -> Light:
+    state = raw.get("state", {})
+    return Light(
+        id=light_id,
+        name=raw.get("name", f"Light {light_id}"),
+        on=state.get("on", False),
+        brightness_pct=round(state.get("bri", 0) / 254 * 100),
+        color=_light_color(state),
+        reachable=state.get("reachable", False),
+    )
+
+
+async def get_lights(config: BridgeConfig) -> list[Light]:
+    if not config.bridge_ip or not config.api_key:
+        raise BridgeNotConfigured()
+
+    url = f"http://{config.bridge_ip}/api/{config.api_key}/lights"
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPError as exc:
+        raise BridgeUnreachable(str(exc)) from exc
+
+    if isinstance(data, list):
+        error = data[0].get("error", {}) if data else {}
+        raise BridgeUnreachable(error.get("description", "bridge returned an error"))
+
+    return [_to_light(light_id, raw) for light_id, raw in data.items()]

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -1,4 +1,5 @@
 import colorsys
+import logging
 import math
 from typing import Optional
 
@@ -6,6 +7,8 @@ import httpx
 from pydantic import BaseModel
 
 from app.config import BridgeConfig
+
+logger = logging.getLogger(__name__)
 
 
 class BridgeNotConfigured(Exception):
@@ -84,13 +87,19 @@ def _ct_to_rgb_hex(mired: int) -> str:
 
 def _light_color(state: dict) -> Optional[str]:
     mode = state.get("colormode")
-    if mode == "xy" and "xy" in state:
-        x, y = state["xy"]
-        return _xy_to_rgb_hex(x, y)
-    if mode == "hs" and "hue" in state and "sat" in state:
-        return _hs_to_rgb_hex(state["hue"], state["sat"])
-    if mode == "ct" and "ct" in state:
-        return _ct_to_rgb_hex(state["ct"])
+    try:
+        if mode == "xy" and "xy" in state:
+            x, y = state["xy"]
+            return _xy_to_rgb_hex(x, y)
+        if mode == "hs" and "hue" in state and "sat" in state:
+            return _hs_to_rgb_hex(state["hue"], state["sat"])
+        if mode == "ct" and "ct" in state:
+            return _ct_to_rgb_hex(state["ct"])
+    except Exception:
+        # A single bulb reporting a malformed color value (e.g. ct=0)
+        # shouldn't take down the whole /api/lights response.
+        logger.warning("Could not compute color for light state %r", state, exc_info=True)
+        return None
     return None
 
 
@@ -117,7 +126,12 @@ async def get_lights(config: BridgeConfig) -> list[Light]:
             resp.raise_for_status()
             data = resp.json()
     except httpx.HTTPError as exc:
-        raise BridgeUnreachable(str(exc)) from exc
+        # Don't forward str(exc) to the caller: httpx.HTTPStatusError's
+        # message embeds the full request URL, which contains api_key.
+        # That would leak the credential to the browser via the 502
+        # response body — log it server-side instead.
+        logger.warning("Request to Hue bridge failed: %s", exc)
+        raise BridgeUnreachable("could not reach the bridge") from exc
 
     if isinstance(data, list):
         error = data[0].get("error", {}) if data else {}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,8 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import load_config
+from app.hue_client import BridgeNotConfigured, BridgeUnreachable, Light, get_lights
 
 app = FastAPI(title="Hue Light Control API")
 
@@ -17,3 +18,14 @@ app.add_middleware(
 def health():
     config = load_config()
     return {"status": "ok", "bridge_configured": config.bridge_ip is not None}
+
+
+@app.get("/api/lights")
+async def list_lights() -> list[Light]:
+    config = load_config()
+    try:
+        return await get_lights(config)
+    except BridgeNotConfigured:
+        raise HTTPException(status_code=503, detail="Bridge not configured")
+    except BridgeUnreachable as exc:
+        raise HTTPException(status_code=502, detail=f"Bridge unreachable: {exc}")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 pydantic
 pyyaml
+httpx

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,8 +1,58 @@
 <script>
-  // Placeholder root component — replaced as the control panel UI is built.
+  import { onMount } from 'svelte'
+  import LightCard from './LightCard.svelte'
+
+  let lights = $state([])
+  let loading = $state(true)
+  let error = $state(null)
+
+  async function loadLights() {
+    loading = true
+    error = null
+    try {
+      const res = await fetch('/api/lights')
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.detail ?? `Request failed (${res.status})`)
+      }
+      lights = await res.json()
+    } catch (err) {
+      error = err.message
+    } finally {
+      loading = false
+    }
+  }
+
+  onMount(loadLights)
 </script>
 
 <main>
   <h1>Hue Light Control</h1>
-  <p>Frontend scaffold — not yet implemented.</p>
+
+  {#if loading}
+    <p>Loading bulbs…</p>
+  {:else if error}
+    <p class="error">{error}</p>
+    <button onclick={loadLights}>Retry</button>
+  {:else if lights.length === 0}
+    <p>No bulbs found.</p>
+  {:else}
+    <div class="grid">
+      {#each lights as light (light.id)}
+        <LightCard {light} />
+      {/each}
+    </div>
+  {/if}
 </main>
+
+<style>
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+    gap: 1rem;
+  }
+
+  .error {
+    color: light-dark(#a3392c, #f0958a);
+  }
+</style>

--- a/frontend/src/LightCard.svelte
+++ b/frontend/src/LightCard.svelte
@@ -6,7 +6,6 @@
   <div class="header">
     <span
       class="swatch"
-      class:off={!light.on}
       style:background-color={light.on ? (light.color ?? '#ffe9b3') : undefined}
     ></span>
     <span class="name">{light.name}</span>

--- a/frontend/src/LightCard.svelte
+++ b/frontend/src/LightCard.svelte
@@ -1,0 +1,113 @@
+<script>
+  let { light } = $props()
+</script>
+
+<div class="card" class:unreachable={!light.reachable}>
+  <div class="header">
+    <span
+      class="swatch"
+      class:off={!light.on}
+      style:background-color={light.on ? (light.color ?? '#ffe9b3') : undefined}
+    ></span>
+    <span class="name">{light.name}</span>
+  </div>
+
+  <div class="status">
+    <span class="badge" class:on={light.on}>{light.on ? 'On' : 'Off'}</span>
+    {#if !light.reachable}
+      <span class="badge unreachable-badge">Unreachable</span>
+    {/if}
+  </div>
+
+  <div class="brightness">
+    <div class="brightness-track">
+      <div class="brightness-fill" style:width="{light.brightness_pct}%"></div>
+    </div>
+    <span class="brightness-label">{light.brightness_pct}%</span>
+  </div>
+</div>
+
+<style>
+  .card {
+    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    border-radius: 0.75rem;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    background: light-dark(#fff, #1e1e1e);
+  }
+
+  .card.unreachable {
+    opacity: 0.55;
+  }
+
+  .header {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  .swatch {
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+    border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.25));
+    background: light-dark(#e2e2e2, #2a2a2a);
+    flex-shrink: 0;
+  }
+
+  .name {
+    font-weight: 600;
+  }
+
+  .status {
+    display: flex;
+    gap: 0.4rem;
+  }
+
+  .badge {
+    font-size: 0.75rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    background: light-dark(#eee, #333);
+    color: light-dark(#555, #ccc);
+    width: fit-content;
+  }
+
+  .badge.on {
+    background: light-dark(#dcf5df, #1f3d24);
+    color: light-dark(#1c7a2e, #7fe396);
+  }
+
+  .unreachable-badge {
+    background: light-dark(#fbe3e0, #3d211f);
+    color: light-dark(#a3392c, #f0958a);
+  }
+
+  .brightness {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .brightness-track {
+    flex: 1;
+    height: 0.4rem;
+    border-radius: 999px;
+    background: light-dark(#eee, #333);
+    overflow: hidden;
+  }
+
+  .brightness-fill {
+    height: 100%;
+    background: light-dark(#333, #ddd);
+  }
+
+  .brightness-label {
+    font-size: 0.75rem;
+    color: light-dark(#666, #aaa);
+    width: 2.5rem;
+    text-align: right;
+  }
+</style>


### PR DESCRIPTION
## Summary
- `backend/app/hue_client.py`: fetches lights from the bridge, normalizes into a clean `Light` model (id, name, on, brightness_pct, color, reachable). Converts Hue's `xy`/`hs`/`ct` color data to a display RGB hex — Philips' documented xyY→sRGB matrix for `xy`, `colorsys` for `hs`, a Kelvin approximation for `ct` — always at full saturation since brightness is reported separately, not baked into the swatch.
- New `GET /api/lights` route: 503 if the bridge isn't configured, 502 if it's unreachable.
- `frontend/src/LightCard.svelte` + updated `App.svelte`: fetch on mount, render one card per bulb (color swatch, name, on/off badge, brightness bar), with loading/error/empty states.
- Read-only — no control path. Matches the issue's actual scope (display, not control).

Closes #4.

## Test plan
- [x] `get_lights()` tested directly against the real bridge (16 bulbs: 6 dimmable, 9 extended-color, 1 color-temp) — output sanity-checked, including plausible RGB values for each colormode
- [x] Full path verified end-to-end: real bridge → backend `/api/lights` → Vite proxy → rendered UI, with real bulb names/states
- [x] Loaded it in a browser and visually confirmed all 16 bulbs render with correct names/on-off/brightness; color swatches looked wrong in that automated browser tool specifically, traced conclusively to the tool's own color handling (a blank test element with the same inline color got identically suppressed) — not the app
- [x] Manually tested by Palmer via locally-run dev servers before this PR was opened, per his request
- [x] Secret sweep of changed files for real network identifiers: clean
- [x] gitleaks pre-commit hook: passed