### PR TITLE
Frontend: display Scenes

### DIFF
--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -161,4 +161,10 @@ def _to_scene(scene_id: str, raw: dict) -> Scene:
 
 async def get_scenes(config: BridgeConfig) -> list[Scene]:
     data = await _bridge_get(config, "scenes")
-    return [_to_scene(scene_id, raw) for scene_id, raw in data.items()]
+    return [
+        _to_scene(scene_id, raw)
+        for scene_id, raw in data.items()
+        # "Recycle" scenes are bridge-internal, created by apps to save/restore
+        # state (e.g. before a light effect) — not scenes a user created.
+        if not raw.get("recycle", False)
+    ]

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -28,6 +28,12 @@ class Light(BaseModel):
     reachable: bool
 
 
+class Scene(BaseModel):
+    id: str
+    name: str
+    light_count: int
+
+
 def _to_hex(r: float, g: float, b: float) -> str:
     return "#{:02x}{:02x}{:02x}".format(round(r * 255), round(g * 255), round(b * 255))
 
@@ -115,11 +121,11 @@ def _to_light(light_id: str, raw: dict) -> Light:
     )
 
 
-async def get_lights(config: BridgeConfig) -> list[Light]:
+async def _bridge_get(config: BridgeConfig, path: str) -> dict:
     if not config.bridge_ip or not config.api_key:
         raise BridgeNotConfigured()
 
-    url = f"http://{config.bridge_ip}/api/{config.api_key}/lights"
+    url = f"http://{config.bridge_ip}/api/{config.api_key}/{path}"
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.get(url)
@@ -137,4 +143,22 @@ async def get_lights(config: BridgeConfig) -> list[Light]:
         error = data[0].get("error", {}) if data else {}
         raise BridgeUnreachable(error.get("description", "bridge returned an error"))
 
+    return data
+
+
+async def get_lights(config: BridgeConfig) -> list[Light]:
+    data = await _bridge_get(config, "lights")
     return [_to_light(light_id, raw) for light_id, raw in data.items()]
+
+
+def _to_scene(scene_id: str, raw: dict) -> Scene:
+    return Scene(
+        id=scene_id,
+        name=raw.get("name", f"Scene {scene_id}"),
+        light_count=len(raw.get("lights", [])),
+    )
+
+
+async def get_scenes(config: BridgeConfig) -> list[Scene]:
+    data = await _bridge_get(config, "scenes")
+    return [_to_scene(scene_id, raw) for scene_id, raw in data.items()]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,14 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import load_config
-from app.hue_client import BridgeNotConfigured, BridgeUnreachable, Light, get_lights
+from app.hue_client import (
+    BridgeNotConfigured,
+    BridgeUnreachable,
+    Light,
+    Scene,
+    get_lights,
+    get_scenes,
+)
 
 app = FastAPI(title="Hue Light Control API")
 
@@ -25,6 +32,17 @@ async def list_lights() -> list[Light]:
     config = load_config()
     try:
         return await get_lights(config)
+    except BridgeNotConfigured:
+        raise HTTPException(status_code=503, detail="Bridge not configured")
+    except BridgeUnreachable as exc:
+        raise HTTPException(status_code=502, detail=f"Bridge unreachable: {exc}")
+
+
+@app.get("/api/scenes")
+async def list_scenes() -> list[Scene]:
+    config = load_config()
+    try:
+        return await get_scenes(config)
     except BridgeNotConfigured:
         raise HTTPException(status_code=503, detail="Bridge not configured")
     except BridgeUnreachable as exc:

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,14 +1,19 @@
 <script>
   import { onMount } from 'svelte'
   import LightCard from './LightCard.svelte'
+  import SceneCard from './SceneCard.svelte'
 
   let lights = $state([])
-  let loading = $state(true)
-  let error = $state(null)
+  let lightsLoading = $state(true)
+  let lightsError = $state(null)
+
+  let scenes = $state([])
+  let scenesLoading = $state(true)
+  let scenesError = $state(null)
 
   async function loadLights() {
-    loading = true
-    error = null
+    lightsLoading = true
+    lightsError = null
     try {
       const res = await fetch('/api/lights')
       if (!res.ok) {
@@ -17,35 +22,80 @@
       }
       lights = await res.json()
     } catch (err) {
-      error = err.message
+      lightsError = err.message
     } finally {
-      loading = false
+      lightsLoading = false
     }
   }
 
-  onMount(loadLights)
+  async function loadScenes() {
+    scenesLoading = true
+    scenesError = null
+    try {
+      const res = await fetch('/api/scenes')
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.detail ?? `Request failed (${res.status})`)
+      }
+      scenes = await res.json()
+    } catch (err) {
+      scenesError = err.message
+    } finally {
+      scenesLoading = false
+    }
+  }
+
+  onMount(() => {
+    loadLights()
+    loadScenes()
+  })
 </script>
 
 <main>
   <h1>Hue Light Control</h1>
 
-  {#if loading}
-    <p>Loading bulbs…</p>
-  {:else if error}
-    <p class="error">{error}</p>
-    <button onclick={loadLights}>Retry</button>
-  {:else if lights.length === 0}
-    <p>No bulbs found.</p>
-  {:else}
-    <div class="grid">
-      {#each lights as light (light.id)}
-        <LightCard {light} />
-      {/each}
-    </div>
-  {/if}
+  <section>
+    <h2>Bulbs</h2>
+    {#if lightsLoading}
+      <p>Loading bulbs…</p>
+    {:else if lightsError}
+      <p class="error">{lightsError}</p>
+      <button onclick={loadLights}>Retry</button>
+    {:else if lights.length === 0}
+      <p>No bulbs found.</p>
+    {:else}
+      <div class="grid">
+        {#each lights as light (light.id)}
+          <LightCard {light} />
+        {/each}
+      </div>
+    {/if}
+  </section>
+
+  <section>
+    <h2>Scenes</h2>
+    {#if scenesLoading}
+      <p>Loading scenes…</p>
+    {:else if scenesError}
+      <p class="error">{scenesError}</p>
+      <button onclick={loadScenes}>Retry</button>
+    {:else if scenes.length === 0}
+      <p>No scenes found.</p>
+    {:else}
+      <div class="grid">
+        {#each scenes as scene (scene.id)}
+          <SceneCard {scene} />
+        {/each}
+      </div>
+    {/if}
+  </section>
 </main>
 
 <style>
+  section + section {
+    margin-top: 2rem;
+  }
+
   .grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));

--- a/frontend/src/SceneCard.svelte
+++ b/frontend/src/SceneCard.svelte
@@ -1,0 +1,33 @@
+<script>
+  let { scene } = $props()
+</script>
+
+<div class="card">
+  <span class="name">{scene.name}</span>
+  <span class="badge">{scene.light_count} {scene.light_count === 1 ? 'light' : 'lights'}</span>
+</div>
+
+<style>
+  .card {
+    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    border-radius: 0.75rem;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    background: light-dark(#fff, #1e1e1e);
+  }
+
+  .name {
+    font-weight: 600;
+  }
+
+  .badge {
+    font-size: 0.75rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    background: light-dark(#eee, #333);
+    color: light-dark(#555, #ccc);
+    width: fit-content;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Add `GET /api/scenes`, backed by a new `get_scenes`/`Scene` model in `hue_client.py`, mirroring the existing `/api/lights` path
- Factor the shared bridge-request/error-handling logic (used by both lights and scenes) into `_bridge_get`
- Add a `Scenes` section to the frontend (`SceneCard.svelte`), with the same independent loading/error/retry states as the Bulbs section

Closes #5

## Test plan
- [x] Unit-checked `_to_scene` parsing against a representative bridge scene payload
- [x] Verified `/api/scenes` returns a 502 with a safe error message when the bridge is unreachable (matches existing `/api/lights` behavior — bridge was not reachable from this dev machine during this session)
- [x] Verified in-browser: Bulbs and Scenes sections load/error independently; confirmed Scene card rendering (name + singular/plural light count) via a mocked `/api/scenes` response