### PR TITLE
Backend: auto-discover bridge IP when last-known IP fails

### DIFF
--- a/backend/app/bridge_discovery.py
+++ b/backend/app/bridge_discovery.py
@@ -1,0 +1,96 @@
+import asyncio
+import logging
+import socket
+import time
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+CLOUD_DISCOVERY_URL = "https://discovery.meethue.com/"
+
+_SSDP_ADDR = "239.255.255.250"
+_SSDP_PORT = 1900
+_SSDP_MX = 3
+_SSDP_SEARCH_TARGET = "urn:schemas-upnp-org:device:basic:1"
+_SSDP_MESSAGE = (
+    "M-SEARCH * HTTP/1.1\r\n"
+    f"HOST: {_SSDP_ADDR}:{_SSDP_PORT}\r\n"
+    'MAN: "ssdp:discover"\r\n'
+    f"MX: {_SSDP_MX}\r\n"
+    f"ST: {_SSDP_SEARCH_TARGET}\r\n"
+    "\r\n"
+).encode()
+
+
+def _ssdp_search(timeout: float) -> Optional[str]:
+    """Send an SSDP M-SEARCH and return the first Hue bridge IP that replies.
+
+    Hue bridges identify themselves in the M-SEARCH response body with an
+    "IpBridge" server string. This is blocking socket I/O — call it via an
+    executor from async code.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    try:
+        sock.sendto(_SSDP_MESSAGE, (_SSDP_ADDR, _SSDP_PORT))
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            sock.settimeout(remaining)
+            try:
+                data, (ip, _port) = sock.recvfrom(2048)
+            except socket.timeout:
+                break
+            if b"IpBridge" in data:
+                return ip
+    except OSError as exc:
+        logger.warning("SSDP discovery failed: %s", exc)
+    finally:
+        sock.close()
+    return None
+
+
+async def discover_local(timeout: float = 5.0) -> Optional[str]:
+    """Find a bridge on the local network via SSDP multicast. Works with no
+    internet access — LAN multicast only."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _ssdp_search, timeout)
+
+
+async def discover_cloud(timeout: float = 5.0) -> Optional[str]:
+    """Find a bridge via Philips' cloud discovery service. Requires internet
+    access, so this is only worth trying when local discovery fails."""
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(CLOUD_DISCOVERY_URL)
+            resp.raise_for_status()
+            bridges = resp.json()
+    except httpx.HTTPError as exc:
+        logger.warning("Cloud discovery failed: %s", exc)
+        return None
+    return bridges[0]["internalipaddress"] if bridges else None
+
+
+async def _verify_bridge(ip: str, api_key: str, timeout: float = 5.0) -> bool:
+    """Confirm a candidate IP is actually our paired bridge (not a neighbor's)
+    by checking it accepts our api_key."""
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(f"http://{ip}/api/{api_key}/config")
+            resp.raise_for_status()
+    except httpx.HTTPError:
+        return False
+    return True
+
+
+async def rediscover_bridge_ip(api_key: str) -> Optional[str]:
+    """Find the bridge's current IP, local discovery first so this works
+    offline, falling back to cloud discovery only if that fails."""
+    for discover in (discover_local, discover_cloud):
+        candidate = await discover()
+        if candidate and await _verify_bridge(candidate, api_key):
+            return candidate
+    return None

--- a/backend/app/bridge_discovery.py
+++ b/backend/app/bridge_discovery.py
@@ -1,4 +1,5 @@
 import asyncio
+import ipaddress
 import logging
 import socket
 import time
@@ -23,13 +24,20 @@ _SSDP_MESSAGE = (
     "\r\n"
 ).encode()
 
+# After a fully-failed rediscovery, skip retrying for this long so a
+# genuinely offline bridge doesn't turn every request into a long hang.
+_FAILURE_COOLDOWN_SECONDS = 60.0
+_last_failure_at: Optional[float] = None
+
 
 def _ssdp_search(timeout: float) -> Optional[str]:
     """Send an SSDP M-SEARCH and return the first Hue bridge IP that replies.
 
     Hue bridges identify themselves in the M-SEARCH response body with an
     "IpBridge" server string. This is blocking socket I/O — call it via an
-    executor from async code.
+    executor from async code. The candidate is confirmed against our own
+    api_key by _verify_bridge before being trusted, since any host that sees
+    the multicast query could in principle reply.
     """
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
     try:
@@ -55,9 +63,20 @@ def _ssdp_search(timeout: float) -> Optional[str]:
 
 async def discover_local(timeout: float = 5.0) -> Optional[str]:
     """Find a bridge on the local network via SSDP multicast. Works with no
-    internet access — LAN multicast only."""
+    internet access — LAN multicast only.
+
+    Note: multicast may not reach the LAN from inside a container on
+    Docker's default bridge network; that needs --network host or macvlan.
+    """
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(None, _ssdp_search, timeout)
+
+
+def _is_private_address(ip: str) -> bool:
+    try:
+        return ipaddress.ip_address(ip).is_private
+    except ValueError:
+        return False
 
 
 async def discover_cloud(timeout: float = 5.0) -> Optional[str]:
@@ -68,29 +87,51 @@ async def discover_cloud(timeout: float = 5.0) -> Optional[str]:
             resp = await client.get(CLOUD_DISCOVERY_URL)
             resp.raise_for_status()
             bridges = resp.json()
-    except httpx.HTTPError as exc:
+        candidate = bridges[0]["internalipaddress"] if bridges else None
+    except (httpx.HTTPError, ValueError, KeyError, IndexError, TypeError) as exc:
         logger.warning("Cloud discovery failed: %s", exc)
         return None
-    return bridges[0]["internalipaddress"] if bridges else None
+
+    if candidate is not None and not _is_private_address(candidate):
+        # Don't send our api_key to whatever this is.
+        logger.warning("Cloud discovery returned a non-private address, ignoring")
+        return None
+    return candidate
 
 
 async def _verify_bridge(ip: str, api_key: str, timeout: float = 5.0) -> bool:
-    """Confirm a candidate IP is actually our paired bridge (not a neighbor's)
-    by checking it accepts our api_key."""
+    """Confirm a candidate IP is actually our paired bridge (not a neighbor's
+    or an unrelated host) by checking it accepts our api_key.
+
+    The bridge always answers HTTP 200, even for a bad api_key — the actual
+    result is conveyed as a JSON error-list body, so raise_for_status()
+    alone can't distinguish "our bridge" from "any Hue bridge".
+    """
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
             resp = await client.get(f"http://{ip}/api/{api_key}/config")
             resp.raise_for_status()
-    except httpx.HTTPError:
+            data = resp.json()
+    except (httpx.HTTPError, ValueError):
         return False
-    return True
+    return not isinstance(data, list)
 
 
 async def rediscover_bridge_ip(api_key: str) -> Optional[str]:
     """Find the bridge's current IP, local discovery first so this works
     offline, falling back to cloud discovery only if that fails."""
+    global _last_failure_at
+    if (
+        _last_failure_at is not None
+        and time.monotonic() - _last_failure_at < _FAILURE_COOLDOWN_SECONDS
+    ):
+        return None
+
     for discover in (discover_local, discover_cloud):
         candidate = await discover()
         if candidate and await _verify_bridge(candidate, api_key):
+            _last_failure_at = None
             return candidate
+
+    _last_failure_at = time.monotonic()
     return None

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -18,3 +18,10 @@ def load_config() -> BridgeConfig:
     with CONFIG_PATH.open() as f:
         data = yaml.safe_load(f) or {}
     return BridgeConfig(**data)
+
+
+def update_bridge_ip(ip: str) -> None:
+    config = load_config()
+    config.bridge_ip = ip
+    with CONFIG_PATH.open("w") as f:
+        yaml.safe_dump(config.model_dump(exclude_none=True), f)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -23,5 +25,14 @@ def load_config() -> BridgeConfig:
 def update_bridge_ip(ip: str) -> None:
     config = load_config()
     config.bridge_ip = ip
-    with CONFIG_PATH.open("w") as f:
-        yaml.safe_dump(config.model_dump(exclude_none=True), f)
+    # Write-then-rename so a crash mid-write can't leave config.yaml
+    # truncated (which would also lose api_key, requiring re-pairing).
+    fd, tmp_path = tempfile.mkstemp(dir=CONFIG_PATH.parent, prefix=".config.yaml.")
+    try:
+        with os.fdopen(fd, "w") as f:
+            yaml.safe_dump(config.model_dump(exclude_none=True), f)
+        os.replace(tmp_path, CONFIG_PATH)
+    except BaseException:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import colorsys
 import logging
 import math
@@ -7,9 +8,14 @@ import httpx
 from pydantic import BaseModel
 
 from app.bridge_discovery import rediscover_bridge_ip
-from app.config import BridgeConfig, update_bridge_ip
+from app.config import BridgeConfig, load_config, update_bridge_ip
 
 logger = logging.getLogger(__name__)
+
+# Serializes rediscovery so concurrent requests (e.g. the frontend's
+# lights + scenes calls firing together) don't each run their own SSDP/cloud
+# search and race to write config.yaml.
+_rediscovery_lock = asyncio.Lock()
 
 
 class BridgeNotConfigured(Exception):
@@ -150,19 +156,30 @@ async def _bridge_get(config: BridgeConfig, path: str) -> dict:
         # — log it server-side instead.
         logger.warning("Could not reach bridge at %s: %s", config.bridge_ip, exc)
 
-    new_ip = await rediscover_bridge_ip(config.api_key)
-    if new_ip is None:
-        raise BridgeUnreachable("could not reach the bridge")
+    async with _rediscovery_lock:
+        # A concurrent request may have already rediscovered and persisted a
+        # working IP while we were waiting for the lock — try that first.
+        current_ip = load_config().bridge_ip
+        if current_ip and current_ip != config.bridge_ip:
+            try:
+                return await _request_bridge(current_ip, config.api_key, path)
+            except httpx.HTTPError:
+                pass
 
-    try:
-        data = await _request_bridge(new_ip, config.api_key, path)
-    except httpx.HTTPError as exc:
-        logger.warning("Rediscovered bridge at %s also unreachable: %s", new_ip, exc)
-        raise BridgeUnreachable("could not reach the bridge") from exc
+        new_ip = await rediscover_bridge_ip(config.api_key)
+        if new_ip is None:
+            raise BridgeUnreachable("could not reach the bridge")
 
-    logger.info("Bridge IP changed (%s -> %s), updating config.yaml", config.bridge_ip, new_ip)
-    update_bridge_ip(new_ip)
-    return data
+        try:
+            data = await _request_bridge(new_ip, config.api_key, path)
+        except httpx.HTTPError as exc:
+            logger.warning("Rediscovered bridge at %s also unreachable: %s", new_ip, exc)
+            raise BridgeUnreachable("could not reach the bridge") from exc
+
+        if new_ip != config.bridge_ip:
+            logger.info("Bridge IP changed (%s -> %s), updating config.yaml", config.bridge_ip, new_ip)
+            update_bridge_ip(new_ip)
+        return data
 
 
 async def get_lights(config: BridgeConfig) -> list[Light]:

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -6,7 +6,8 @@ from typing import Optional
 import httpx
 from pydantic import BaseModel
 
-from app.config import BridgeConfig
+from app.bridge_discovery import rediscover_bridge_ip
+from app.config import BridgeConfig, update_bridge_ip
 
 logger = logging.getLogger(__name__)
 
@@ -121,28 +122,46 @@ def _to_light(light_id: str, raw: dict) -> Light:
     )
 
 
-async def _bridge_get(config: BridgeConfig, path: str) -> dict:
-    if not config.bridge_ip or not config.api_key:
-        raise BridgeNotConfigured()
-
-    url = f"http://{config.bridge_ip}/api/{config.api_key}/{path}"
-    try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.get(url)
-            resp.raise_for_status()
-            data = resp.json()
-    except httpx.HTTPError as exc:
-        # Don't forward str(exc) to the caller: httpx.HTTPStatusError's
-        # message embeds the full request URL, which contains api_key.
-        # That would leak the credential to the browser via the 502
-        # response body — log it server-side instead.
-        logger.warning("Request to Hue bridge failed: %s", exc)
-        raise BridgeUnreachable("could not reach the bridge") from exc
+async def _request_bridge(ip: str, api_key: str, path: str) -> dict:
+    url = f"http://{ip}/api/{api_key}/{path}"
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        data = resp.json()
 
     if isinstance(data, list):
         error = data[0].get("error", {}) if data else {}
         raise BridgeUnreachable(error.get("description", "bridge returned an error"))
 
+    return data
+
+
+async def _bridge_get(config: BridgeConfig, path: str) -> dict:
+    if not config.bridge_ip or not config.api_key:
+        raise BridgeNotConfigured()
+
+    try:
+        return await _request_bridge(config.bridge_ip, config.api_key, path)
+    except httpx.HTTPError as exc:
+        # A network-level failure (unreachable/timed out) — the bridge may
+        # have gotten a new IP. Don't forward str(exc): httpx.HTTPStatusError's
+        # message embeds the full request URL, which contains api_key. That
+        # would leak the credential to the browser via the 502 response body
+        # — log it server-side instead.
+        logger.warning("Could not reach bridge at %s: %s", config.bridge_ip, exc)
+
+    new_ip = await rediscover_bridge_ip(config.api_key)
+    if new_ip is None:
+        raise BridgeUnreachable("could not reach the bridge")
+
+    try:
+        data = await _request_bridge(new_ip, config.api_key, path)
+    except httpx.HTTPError as exc:
+        logger.warning("Rediscovered bridge at %s also unreachable: %s", new_ip, exc)
+        raise BridgeUnreachable("could not reach the bridge") from exc
+
+    logger.info("Bridge IP changed (%s -> %s), updating config.yaml", config.bridge_ip, new_ip)
+    update_bridge_ip(new_ip)
     return data
 
 


### PR DESCRIPTION
## Summary
- Add `backend/app/bridge_discovery.py`: local SSDP multicast discovery (`discover_local`, works offline), Philips cloud discovery (`discover_cloud`, fallback, requires internet), and `rediscover_bridge_ip` which tries local first, only falls back to cloud if that fails, and verifies a candidate actually accepts our `api_key` before trusting it (so we don't get fooled by a neighbor's bridge)
- `hue_client._bridge_get` now catches network-level failures (not bridge-returned errors — those wouldn't be fixed by a new IP) against the configured `bridge_ip`, attempts rediscovery, retries once against the new IP, and on success persists it via the new `config.update_bridge_ip`
- Config's `bridge_ip` becomes self-healing: once rediscovered, `config.yaml` is updated so the next request just uses the corrected IP directly

Closes #16

## Test plan
- [x] Unit-tested `_bridge_get` against mocks for: rediscovery succeeds (config gets updated), rediscovery finds nothing (clean `BridgeUnreachable`, no config write), and the happy path (rediscovery never triggered)
- [x] Verified `config.update_bridge_ip` round-trips correctly against a real `config.yaml` (preserves `api_key`, updates only `bridge_ip`)
- [x] **Live end-to-end test against the real bridge**, whose IP actually had changed: first request to the stale IP failed, local SSDP discovery found the bridge in <1s, verification against `api_key` succeeded, the request completed, and `config.yaml` was updated automatically. Every request since has used the corrected IP directly (~0.07s, no rediscovery overhead)
- [x] Verified in-browser: Bulbs and Scenes both load real data through the corrected IP