### PR TITLE
Frontend: get Zones and group Scenes by their respective Zones

### DIFF
--- a/backend/HUE_API.md
+++ b/backend/HUE_API.md
@@ -32,21 +32,31 @@ and stored in `config.yaml` as `api_key`.
 Relevant `state` fields returned per light: `on`, `bri`, `hue`, `sat`, `xy`,
 `ct`, `colormode`, `reachable`.
 
-## Groups (rooms/zones)
+## Groups (rooms/zones) (issue: get Zones, group Scenes by Zone)
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/api/<username>/groups` | List groups (rooms/zones) and their member lights. |
+| GET | `/api/<username>/groups` | List groups and their member lights. |
 | GET | `/api/<username>/groups/<id>` | Single group. |
 | PUT | `/api/<username>/groups/<id>/action` | Apply state to every light in the group at once; also how a scene gets activated (see below). |
 
-## Scenes (issue: display Scenes)
+A group's `type` distinguishes what it represents: `Room` (one light belongs
+to at most one room), `Zone` (user-defined, can span rooms and overlap),
+`Entertainment` (entertainment areas), plus bridge/app-internal `LightGroup`s.
+Only `Zone` groups are surfaced by this app's `/api/zones` endpoint.
+
+## Scenes (issue: display Scenes; issue: group Scenes by Zone)
 
 | Method | Path | Purpose |
 |---|---|---|
 | GET | `/api/<username>/scenes` | List configured scenes (id, name, member lights). |
 | GET | `/api/<username>/scenes/<id>` | Scene detail, including per-light stored states. |
 | PUT | `/api/<username>/groups/<id>/action` | Activate a scene: body `{"scene": "<scene-id>"}`. Hue has no dedicated "activate" endpoint — scenes are applied through the owning group's action endpoint. |
+
+A `GroupScene` carries a `group` field naming the group (room, zone, or
+other) it was created for; this app's `/api/scenes` passes that through as
+`group_id` so the frontend can bucket scenes under their owning zone.
+Standalone `LightScene`s have no `group` and surface with `group_id: null`.
 
 ## Notes
 

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -39,6 +39,13 @@ class Scene(BaseModel):
     id: str
     name: str
     light_count: int
+    group_id: Optional[str] = None
+
+
+class Zone(BaseModel):
+    id: str
+    name: str
+    light_count: int
 
 
 def _to_hex(r: float, g: float, b: float) -> str:
@@ -192,6 +199,9 @@ def _to_scene(scene_id: str, raw: dict) -> Scene:
         id=scene_id,
         name=raw.get("name", f"Scene {scene_id}"),
         light_count=len(raw.get("lights", [])),
+        # Only GroupScenes have this; ties the scene to the group (room/zone)
+        # it was created for. Absent for standalone LightScenes.
+        group_id=raw.get("group"),
     )
 
 
@@ -203,4 +213,24 @@ async def get_scenes(config: BridgeConfig) -> list[Scene]:
         # "Recycle" scenes are bridge-internal, created by apps to save/restore
         # state (e.g. before a light effect) — not scenes a user created.
         if not raw.get("recycle", False)
+    ]
+
+
+def _to_zone(group_id: str, raw: dict) -> Zone:
+    return Zone(
+        id=group_id,
+        name=raw.get("name", f"Zone {group_id}"),
+        light_count=len(raw.get("lights", [])),
+    )
+
+
+async def get_zones(config: BridgeConfig) -> list[Zone]:
+    data = await _bridge_get(config, "groups")
+    return [
+        _to_zone(group_id, raw)
+        for group_id, raw in data.items()
+        # The bridge's "groups" endpoint also returns Rooms, Entertainment
+        # areas, and the LightGroups apps create — only Zones are user-defined
+        # cross-room groupings we want surfaced here.
+        if raw.get("type") == "Zone"
     ]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,8 +7,10 @@ from app.hue_client import (
     BridgeUnreachable,
     Light,
     Scene,
+    Zone,
     get_lights,
     get_scenes,
+    get_zones,
 )
 
 app = FastAPI(title="Hue Light Control API")
@@ -43,6 +45,17 @@ async def list_scenes() -> list[Scene]:
     config = load_config()
     try:
         return await get_scenes(config)
+    except BridgeNotConfigured:
+        raise HTTPException(status_code=503, detail="Bridge not configured")
+    except BridgeUnreachable as exc:
+        raise HTTPException(status_code=502, detail=f"Bridge unreachable: {exc}")
+
+
+@app.get("/api/zones")
+async def list_zones() -> list[Zone]:
+    config = load_config()
+    try:
+        return await get_zones(config)
     except BridgeNotConfigured:
         raise HTTPException(status_code=503, detail="Bridge not configured")
     except BridgeUnreachable as exc:

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -3,6 +3,15 @@
   import LightCard from './LightCard.svelte'
   import SceneCard from './SceneCard.svelte'
 
+  async function fetchJson(url) {
+    const res = await fetch(url)
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      throw new Error(body.detail ?? `Request failed (${res.status})`)
+    }
+    return res.json()
+  }
+
   let lights = $state([])
   let lightsLoading = $state(true)
   let lightsError = $state(null)
@@ -19,12 +28,7 @@
     lightsLoading = true
     lightsError = null
     try {
-      const res = await fetch('/api/lights')
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}))
-        throw new Error(body.detail ?? `Request failed (${res.status})`)
-      }
-      lights = await res.json()
+      lights = await fetchJson('/api/lights')
     } catch (err) {
       lightsError = err.message
     } finally {
@@ -36,12 +40,7 @@
     scenesLoading = true
     scenesError = null
     try {
-      const res = await fetch('/api/scenes')
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}))
-        throw new Error(body.detail ?? `Request failed (${res.status})`)
-      }
-      scenes = await res.json()
+      scenes = await fetchJson('/api/scenes')
     } catch (err) {
       scenesError = err.message
     } finally {
@@ -53,12 +52,7 @@
     zonesLoading = true
     zonesError = null
     try {
-      const res = await fetch('/api/zones')
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}))
-        throw new Error(body.detail ?? `Request failed (${res.status})`)
-      }
-      zones = await res.json()
+      zones = await fetchJson('/api/zones')
     } catch (err) {
       zonesError = err.message
     } finally {
@@ -74,8 +68,8 @@
 
   // Buckets scenes under the zone they belong to. Scenes tied to a Room, an
   // Entertainment area, or no group at all (standalone LightScenes) don't
-  // match any zone and land in "Other" — including, transiently, every scene
-  // while zones are still loading or failed to load.
+  // match any zone and land in "Other" — as does every scene if zones failed
+  // to load.
   let zoneGroups = $derived.by(() => {
     const byId = new Map(zones.map((zone) => [zone.id, { id: zone.id, name: zone.name, scenes: [] }]))
     const other = { id: 'other', name: 'Other', scenes: [] }
@@ -110,10 +104,7 @@
 
   <section>
     <h2>Scenes</h2>
-    {#if zonesError}
-      <p class="error">Couldn't load zones ({zonesError}) — showing scenes ungrouped.</p>
-    {/if}
-    {#if scenesLoading}
+    {#if scenesLoading || zonesLoading}
       <p>Loading scenes…</p>
     {:else if scenesError}
       <p class="error">{scenesError}</p>
@@ -121,6 +112,12 @@
     {:else if scenes.length === 0}
       <p>No scenes found.</p>
     {:else}
+      {#if zonesError}
+        <p class="error">
+          Couldn't load zones ({zonesError}) — showing scenes ungrouped.
+          <button onclick={loadZones}>Retry</button>
+        </p>
+      {/if}
       {#each zoneGroups as group (group.id)}
         <div class="zone-group">
           <h3>{group.name}</h3>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -11,6 +11,10 @@
   let scenesLoading = $state(true)
   let scenesError = $state(null)
 
+  let zones = $state([])
+  let zonesLoading = $state(true)
+  let zonesError = $state(null)
+
   async function loadLights() {
     lightsLoading = true
     lightsError = null
@@ -45,9 +49,41 @@
     }
   }
 
+  async function loadZones() {
+    zonesLoading = true
+    zonesError = null
+    try {
+      const res = await fetch('/api/zones')
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.detail ?? `Request failed (${res.status})`)
+      }
+      zones = await res.json()
+    } catch (err) {
+      zonesError = err.message
+    } finally {
+      zonesLoading = false
+    }
+  }
+
   onMount(() => {
     loadLights()
     loadScenes()
+    loadZones()
+  })
+
+  // Buckets scenes under the zone they belong to. Scenes tied to a Room, an
+  // Entertainment area, or no group at all (standalone LightScenes) don't
+  // match any zone and land in "Other" — including, transiently, every scene
+  // while zones are still loading or failed to load.
+  let zoneGroups = $derived.by(() => {
+    const byId = new Map(zones.map((zone) => [zone.id, { id: zone.id, name: zone.name, scenes: [] }]))
+    const other = { id: 'other', name: 'Other', scenes: [] }
+    for (const scene of scenes) {
+      const group = byId.get(scene.group_id) ?? other
+      group.scenes.push(scene)
+    }
+    return [...byId.values(), other].filter((group) => group.scenes.length > 0)
   })
 </script>
 
@@ -74,6 +110,9 @@
 
   <section>
     <h2>Scenes</h2>
+    {#if zonesError}
+      <p class="error">Couldn't load zones ({zonesError}) — showing scenes ungrouped.</p>
+    {/if}
     {#if scenesLoading}
       <p>Loading scenes…</p>
     {:else if scenesError}
@@ -82,11 +121,16 @@
     {:else if scenes.length === 0}
       <p>No scenes found.</p>
     {:else}
-      <div class="grid">
-        {#each scenes as scene (scene.id)}
-          <SceneCard {scene} />
-        {/each}
-      </div>
+      {#each zoneGroups as group (group.id)}
+        <div class="zone-group">
+          <h3>{group.name}</h3>
+          <div class="grid">
+            {#each group.scenes as scene (scene.id)}
+              <SceneCard {scene} />
+            {/each}
+          </div>
+        </div>
+      {/each}
     {/if}
   </section>
 </main>
@@ -100,6 +144,16 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
     gap: 1rem;
+  }
+
+  .zone-group + .zone-group {
+    margin-top: 1.5rem;
+  }
+
+  .zone-group h3 {
+    margin: 0 0 0.75rem;
+    font-size: 0.95rem;
+    color: light-dark(#555, #aaa);
   }
 
   .error {


### PR DESCRIPTION
## Summary
- Adds `GET /api/zones`, filtering the bridge's `/groups` to only entries of type `Zone` (excludes Rooms, Entertainment areas, and app-internal LightGroups)
- Adds `group_id` to the `Scene` model, passed through from the bridge's `GroupScene.group` field
- Frontend fetches zones alongside scenes and buckets each zone's scenes under its own heading; scenes tied to a Room, an Entertainment area, or no group (standalone LightScenes) fall into an "Other" section
- If zone loading fails, scenes still render (ungrouped) with a small inline notice, rather than blocking the whole Scenes section

Closes #18.

## Test plan
- [x] Verified against the live bridge: `/api/zones` returns only `type: "Zone"` groups (confirmed Rooms/Entertainment areas are excluded)
- [x] Manually tested in browser (`make dev`): Scenes render grouped under their Zone headings (e.g. "Home Office", "Corner Color", "Kitchen & Chandelier", "ALL LIGHTS"), with Room-scoped scenes correctly landing in "Other"