### PR TITLE
Frontend: create Scenes

### DIFF
--- a/backend/HUE_API.md
+++ b/backend/HUE_API.md
@@ -51,12 +51,62 @@ Only `Zone` groups are surfaced by this app's `/api/zones` endpoint.
 |---|---|---|
 | GET | `/api/<username>/scenes` | List configured scenes (id, name, member lights). |
 | GET | `/api/<username>/scenes/<id>` | Scene detail, including per-light stored states. |
+| POST | `/api/<username>/scenes` | Create a scene from lights' *current* live state (see below). |
+| DELETE | `/api/<username>/scenes/<id>` | Delete a scene. |
 | PUT | `/api/<username>/groups/<id>/action` | Activate a scene: body `{"scene": "<scene-id>"}`. Hue has no dedicated "activate" endpoint — scenes are applied through the owning group's action endpoint. |
 
 A `GroupScene` carries a `group` field naming the group (room, zone, or
 other) it was created for; this app's `/api/scenes` passes that through as
 `group_id` so the frontend can bucket scenes under their owning zone.
 Standalone `LightScene`s have no `group` and surface with `group_id: null`.
+
+### Creating a scene (issue: create Scenes)
+
+Not documented anywhere the app previously referenced — confirmed directly
+against a real bridge. `POST /api/<username>/scenes`, body shape depends on
+whether the scene is tied to a group:
+
+**Standalone `LightScene`** (no zone/group selected):
+```json
+{"name": "Reading", "lights": ["1", "2"], "recycle": false, "type": "LightScene"}
+```
+`lights` is required and non-empty (omitting it returns error type 5,
+"invalid/missing parameters in body"). `type` can be omitted — the bridge
+defaults an untyped create to `LightScene` — but is sent explicitly here
+for clarity. `recycle: false` marks it a user-visible scene rather than an
+app-internal state snapshot (see the `recycle` filter in `get_scenes`).
+
+**`GroupScene`** (tied to a zone):
+```json
+{"name": "Movie Night", "recycle": false, "type": "GroupScene", "group": "3"}
+```
+Critically, **`lights` must be omitted entirely** — including it alongside
+`group` (even with a value that exactly matches the group's own members)
+is rejected with `{"error": {"type": 14, "description": "Conflicting
+parameter, type: GroupScenes"}}`. A GroupScene's membership is derived
+solely from the group at creation time; there's no way to create it with a
+subset of the group's lights. This means a light-picker in the UI is only
+meaningful for a standalone `LightScene` — once a zone is selected, the
+resulting scene captures *every* light currently in that zone, regardless
+of what was checked.
+
+**Response** (both cases), matching the standard write-response shape:
+```json
+[{"success": {"id": "<bridge-assigned-scene-id>"}}]
+```
+or an error list like `[{"error": {"type": ..., "description": "..."}}]`.
+
+**Name length**: capped at 32 characters. A 33-character name is rejected
+with `{"error": {"type": 7, "description": "invalid value, ..., for
+parameter, name"}}`; 32 succeeds. (This is CLIP v1's traditional cap,
+confirmed exactly by binary-testing 32 vs. 33 chars against a real bridge.)
+
+**No target values**: the create body has no fields for target on/bri/xy/
+etc. — a scene always snapshots the involved lights' state *as it is at
+creation time* (confirmed via `GET /scenes/<id>` immediately after
+creating one: `lightstates` matched the lights' actual current state).
+There is no way to create a scene with lights set to values other than
+whatever they're currently at.
 
 ## Notes
 

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -179,13 +179,16 @@ async def _request_bridge(
 async def _bridge_request(
     config: BridgeConfig, path: str, *, method: str = "GET", json_body: Optional[dict] = None
 ) -> dict:
-    # Note for future write-route authors: on a genuine network failure, the
-    # retry path below blindly re-sends the same json_body against a
-    # rediscovered/newly-current IP. That's fine for idempotent writes (e.g.
-    # "set brightness to X") but could double-fire a non-idempotent one
-    # (e.g. "toggle") if the original request actually reached the bridge
-    # before the connection dropped. No write route exists yet, so this is
-    # speculative — revisit if/when one needs stricter at-most-once semantics.
+    # On a genuine network failure, the retry path below blindly re-sends
+    # the same json_body against a rediscovered/newly-current IP. That's
+    # fine for idempotent methods (GET, and PUT writes like "set brightness
+    # to X" or "toggle" — resending the same target state twice is
+    # harmless) but would double-fire a non-idempotent POST (e.g.
+    # create_scene) if the original request actually reached the bridge
+    # before the connection dropped, silently creating a duplicate. So POST
+    # skips rediscovery/retry entirely on a network error and just raises —
+    # the caller (a form submission) can retry manually, which is normal
+    # and doesn't risk a silent duplicate.
     if not config.bridge_ip or not config.api_key:
         raise BridgeNotConfigured()
 
@@ -204,6 +207,8 @@ async def _bridge_request(
         # bridge may have gotten a new IP. Don't forward str(exc): same
         # api_key-leak concern as above — log it server-side instead.
         logger.warning("Could not reach bridge at %s: %s", config.bridge_ip, exc)
+        if method == "POST":
+            raise BridgeUnreachable("could not reach the bridge") from exc
 
     async with _rediscovery_lock:
         # A concurrent request may have already rediscovered and persisted a

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -282,3 +282,37 @@ async def get_zones(config: BridgeConfig) -> list[Zone]:
         # cross-room groupings we want surfaced here.
         if raw.get("type") == "Zone"
     ]
+
+
+async def create_scene(
+    config: BridgeConfig, name: str, light_ids: list[str], group_id: Optional[str] = None
+) -> str:
+    """Create a scene from the given lights' *current* live state.
+
+    CLIP v1 has no way to set target on/bri/color values in the create body
+    — it snapshots whatever the lights are set to right now.
+
+    Confirmed against a real bridge (not documented in HUE_API.md's source
+    material): a GroupScene's membership is derived entirely from its
+    `group` — the bridge rejects a request that includes both `group` and an
+    explicit `lights` list with a "Conflicting parameter" error (type 14).
+    So `light_ids` is only sent for a standalone LightScene; for a
+    GroupScene it's ignored here (the caller may still send it to satisfy
+    the request schema, but it plays no part in what the bridge stores).
+    """
+    if group_id is not None:
+        body = {"name": name, "recycle": False, "type": "GroupScene", "group": group_id}
+    else:
+        body = {"name": name, "lights": light_ids, "recycle": False, "type": "LightScene"}
+    result = await _bridge_request(config, "scenes", method="POST", json_body=body)
+    return result[0]["success"]["id"]
+
+
+async def get_group_light_count(config: BridgeConfig, group_id: str) -> int:
+    """Light count for a single group.
+
+    Used right after creating a GroupScene to report its true membership —
+    see create_scene's docstring for why that isn't simply len(light_ids).
+    """
+    data = await _bridge_request(config, f"groups/{group_id}")
+    return len(data.get("lights", []))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,9 @@
+from typing import Optional
+
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
 
 from app.config import load_config
 from app.hue_client import (
@@ -9,6 +12,8 @@ from app.hue_client import (
     Light,
     Scene,
     Zone,
+    create_scene,
+    get_group_light_count,
     get_lights,
     get_scenes,
     get_zones,
@@ -56,3 +61,25 @@ async def list_scenes() -> list[Scene]:
 async def list_zones() -> list[Zone]:
     config = load_config()
     return await get_zones(config)
+
+
+class SceneCreateRequest(BaseModel):
+    # 32 chars is CLIP v1's actual cap, confirmed against a real bridge
+    # (a 33-char name is rejected with error type 7, "invalid value").
+    name: str = Field(..., min_length=1, max_length=32)
+    light_ids: list[str] = Field(..., min_length=1)
+    group_id: Optional[str] = None
+
+
+@app.post("/api/scenes", status_code=201)
+async def create_scene_route(body: SceneCreateRequest) -> Scene:
+    config = load_config()
+    scene_id = await create_scene(config, body.name, body.light_ids, body.group_id)
+    if body.group_id is not None:
+        # A GroupScene's membership comes from the group, not light_ids the
+        # caller sent (see create_scene) — fetch the true count rather than
+        # synthesizing a possibly-wrong one from the request body.
+        light_count = await get_group_light_count(config, body.group_id)
+    else:
+        light_count = len(body.light_ids)
+    return Scene(id=scene_id, name=body.name, light_count=light_count, group_id=body.group_id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,10 @@
+import asyncio
 from typing import Optional
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.config import load_config
 from app.hue_client import (
@@ -70,16 +71,30 @@ class SceneCreateRequest(BaseModel):
     light_ids: list[str] = Field(..., min_length=1)
     group_id: Optional[str] = None
 
+    @field_validator("group_id")
+    @classmethod
+    def _empty_group_id_is_no_group(cls, value: Optional[str]) -> Optional[str]:
+        # The frontend already normalizes "no zone selected" to null, but a
+        # direct API caller could send "" instead — treat that the same way
+        # rather than passing group="" through to create_scene, which the
+        # bridge would reject with an opaque 502.
+        return value or None
+
 
 @app.post("/api/scenes", status_code=201)
 async def create_scene_route(body: SceneCreateRequest) -> Scene:
     config = load_config()
-    scene_id = await create_scene(config, body.name, body.light_ids, body.group_id)
     if body.group_id is not None:
         # A GroupScene's membership comes from the group, not light_ids the
         # caller sent (see create_scene) — fetch the true count rather than
-        # synthesizing a possibly-wrong one from the request body.
-        light_count = await get_group_light_count(config, body.group_id)
+        # synthesizing a possibly-wrong one from the request body. This
+        # doesn't depend on the scene-creation result, so run both calls
+        # concurrently instead of paying for two round-trips in series.
+        scene_id, light_count = await asyncio.gather(
+            create_scene(config, body.name, body.light_ids, body.group_id),
+            get_group_light_count(config, body.group_id),
+        )
     else:
+        scene_id = await create_scene(config, body.name, body.light_ids, body.group_id)
         light_count = len(body.light_ids)
     return Scene(id=scene_id, name=body.name, light_count=light_count, group_id=body.group_id)

--- a/backend/tests/test_hue_client_write.py
+++ b/backend/tests/test_hue_client_write.py
@@ -106,6 +106,26 @@ async def test_network_error_triggers_rediscovery(monkeypatch):
     assert result == [{"success": {"/lights/1/state/bri": 50}}]
 
 
+@respx.mock
+async def test_post_network_error_skips_rediscovery(monkeypatch):
+    # Unlike GET/PUT, a POST (e.g. create_scene) is not idempotent — blindly
+    # resending the same body after a network failure could create a
+    # duplicate scene if the original request actually reached the bridge
+    # before the connection dropped. So a POST should raise directly on a
+    # network error rather than attempting rediscovery-and-resend.
+    config = BridgeConfig(bridge_ip="192.168.x.x", api_key="test-api-key")
+
+    async def fail_if_called(api_key):
+        raise AssertionError("rediscovery should not run for a POST network error")
+
+    monkeypatch.setattr("app.hue_client.rediscover_bridge_ip", fail_if_called)
+
+    respx.post(f"{BRIDGE_URL}/scenes").mock(side_effect=httpx.ConnectError("connection refused"))
+
+    with pytest.raises(BridgeUnreachable, match="could not reach the bridge"):
+        await _bridge_request(config, "scenes", method="POST", json_body={"name": "Test"})
+
+
 @pytest.mark.parametrize(
     ("pct", "bri"),
     [

--- a/backend/tests/test_scene_create.py
+++ b/backend/tests/test_scene_create.py
@@ -62,6 +62,29 @@ async def test_create_light_scene_without_group(client):
     }
 
 
+@respx.mock
+async def test_create_scene_empty_string_group_id_treated_as_no_group(client):
+    # A direct API caller could send group_id: "" instead of null/omitted
+    # (the frontend always normalizes to null, but the API shouldn't rely
+    # on that) — it should behave exactly like no group_id was given,
+    # rather than passing group="" through to the bridge and surfacing an
+    # opaque 502.
+    scenes_route = respx.post(f"{BRIDGE_URL}/scenes").mock(
+        return_value=Response(200, json=[{"success": {"id": "new789"}}])
+    )
+
+    resp = await client.post("/api/scenes", json={"name": "Reading", "light_ids": ["1"], "group_id": ""})
+
+    assert resp.status_code == 201
+    assert json.loads(scenes_route.calls.last.request.content) == {
+        "name": "Reading",
+        "lights": ["1"],
+        "recycle": False,
+        "type": "LightScene",
+    }
+    assert resp.json()["group_id"] is None
+
+
 async def test_create_scene_empty_name_is_422(client):
     resp = await client.post("/api/scenes", json={"name": "", "light_ids": ["1"]})
 

--- a/backend/tests/test_scene_create.py
+++ b/backend/tests/test_scene_create.py
@@ -1,0 +1,85 @@
+import json
+
+import respx
+from httpx import Response
+
+BRIDGE_URL = "http://192.168.x.x/api/test-api-key"
+
+
+@respx.mock
+async def test_create_group_scene(client):
+    scenes_route = respx.post(f"{BRIDGE_URL}/scenes").mock(
+        return_value=Response(200, json=[{"success": {"id": "new123"}}])
+    )
+    respx.get(f"{BRIDGE_URL}/groups/3").mock(
+        return_value=Response(200, json={"name": "Living Room", "lights": ["1", "2", "5"], "type": "Zone"})
+    )
+
+    resp = await client.post(
+        "/api/scenes", json={"name": "Movie Night", "light_ids": ["1", "2"], "group_id": "3"}
+    )
+
+    assert resp.status_code == 201
+    # A GroupScene's membership is derived from the group itself — the
+    # bridge rejects a request that also includes an explicit `lights` list
+    # alongside `group` (confirmed live: "Conflicting parameter" error).
+    assert json.loads(scenes_route.calls.last.request.content) == {
+        "name": "Movie Night",
+        "recycle": False,
+        "type": "GroupScene",
+        "group": "3",
+    }
+    assert resp.json() == {
+        "id": "new123",
+        "name": "Movie Night",
+        # Reflects the group's actual membership (3 lights), not the 2
+        # light_ids that were submitted — those don't apply to a GroupScene.
+        "light_count": 3,
+        "group_id": "3",
+    }
+
+
+@respx.mock
+async def test_create_light_scene_without_group(client):
+    scenes_route = respx.post(f"{BRIDGE_URL}/scenes").mock(
+        return_value=Response(200, json=[{"success": {"id": "new456"}}])
+    )
+
+    resp = await client.post("/api/scenes", json={"name": "Reading", "light_ids": ["1", "2"]})
+
+    assert resp.status_code == 201
+    assert json.loads(scenes_route.calls.last.request.content) == {
+        "name": "Reading",
+        "lights": ["1", "2"],
+        "recycle": False,
+        "type": "LightScene",
+    }
+    assert resp.json() == {
+        "id": "new456",
+        "name": "Reading",
+        "light_count": 2,
+        "group_id": None,
+    }
+
+
+async def test_create_scene_empty_name_is_422(client):
+    resp = await client.post("/api/scenes", json={"name": "", "light_ids": ["1"]})
+
+    assert resp.status_code == 422
+
+
+async def test_create_scene_empty_light_ids_is_422(client):
+    resp = await client.post("/api/scenes", json={"name": "Reading", "light_ids": []})
+
+    assert resp.status_code == 422
+
+
+@respx.mock
+async def test_create_scene_bridge_error_returns_502(client):
+    respx.post(f"{BRIDGE_URL}/scenes").mock(
+        return_value=Response(200, json=[{"error": {"description": "invalid/missing parameters in body"}}])
+    )
+
+    resp = await client.post("/api/scenes", json={"name": "Reading", "light_ids": ["1"]})
+
+    assert resp.status_code == 502

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2,7 +2,8 @@
   import { onMount } from 'svelte'
   import LightCard from './LightCard.svelte'
   import SceneCard from './SceneCard.svelte'
-  import { fetchJson } from './api.js'
+  import CreateSceneForm from './CreateSceneForm.svelte'
+  import { fetchJson, postJson } from './api.js'
 
   let lights = $state([])
   let lightsLoading = $state(true)
@@ -71,6 +72,13 @@
     }
     return [...byId.values(), other].filter((group) => group.scenes.length > 0)
   })
+
+  let showCreateForm = $state(false)
+
+  async function createScene(name, lightIds, groupId) {
+    const scene = await postJson('/api/scenes', { name, light_ids: lightIds, group_id: groupId })
+    scenes = [...scenes, scene]
+  }
 </script>
 
 <main>
@@ -95,7 +103,18 @@
   </section>
 
   <section>
-    <h2>Scenes</h2>
+    <div class="section-header">
+      <h2>Scenes</h2>
+      <button onclick={() => (showCreateForm = true)}>+ New Scene</button>
+    </div>
+    {#if showCreateForm}
+      <CreateSceneForm
+        {lights}
+        {zones}
+        onCreate={createScene}
+        onClose={() => (showCreateForm = false)}
+      />
+    {/if}
     {#if scenesLoading || zonesLoading}
       <p>Loading scenes…</p>
     {:else if scenesError}
@@ -127,6 +146,27 @@
 <style>
   section + section {
     margin-top: 2rem;
+  }
+
+  .section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .section-header h2 {
+    margin: 0;
+  }
+
+  .section-header button {
+    font: inherit;
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    background: light-dark(#eee, #333);
+    color: inherit;
+    cursor: pointer;
   }
 
   .grid {

--- a/frontend/src/CreateSceneForm.svelte
+++ b/frontend/src/CreateSceneForm.svelte
@@ -10,17 +10,17 @@
   let submitting = $state(false)
   let error = $state(null)
 
-  let canSubmit = $derived(name.trim().length > 0 && selectedLightIds.length > 0 && !submitting)
+  // Once a zone is selected, the created scene captures the zone's actual
+  // membership regardless of what's checked below (see the hint text and
+  // HUE_API.md) — so light selection is only required when creating a
+  // standalone scene with no zone.
+  let canSubmit = $derived(
+    name.trim().length > 0 && (selectedZoneId || selectedLightIds.length > 0) && !submitting
+  )
 
   onMount(() => {
     dialog?.showModal()
   })
-
-  function toggleLight(lightId) {
-    selectedLightIds = selectedLightIds.includes(lightId)
-      ? selectedLightIds.filter((id) => id !== lightId)
-      : [...selectedLightIds, lightId]
-  }
 
   async function handleSubmit(event) {
     event.preventDefault()
@@ -37,9 +37,20 @@
   }
 
   function handleBackdropClick(event) {
-    // A click that lands on the <dialog> element itself (rather than
-    // something inside the <form>) is a click on the backdrop.
-    if (event.target === dialog) {
+    // Any click that doesn't land on a child element (backdrop AND the
+    // dialog's own padding around <form>) reports target === dialog — so
+    // that check alone can't tell a real backdrop click from one that
+    // landed in the card's padding (visually still inside the card).
+    // Compare coordinates against the dialog's own rendered box instead
+    // (its border box, which includes the padding): only a click outside
+    // that box is a real click on the backdrop.
+    const rect = dialog.getBoundingClientRect()
+    const outside =
+      event.clientX < rect.left ||
+      event.clientX > rect.right ||
+      event.clientY < rect.top ||
+      event.clientY > rect.bottom
+    if (outside) {
       dialog.close()
     }
   }
@@ -62,11 +73,7 @@
         <div class="light-list">
           {#each lights as light (light.id)}
             <label class="light-option">
-              <input
-                type="checkbox"
-                checked={selectedLightIds.includes(light.id)}
-                onchange={() => toggleLight(light.id)}
-              />
+              <input type="checkbox" bind:group={selectedLightIds} value={light.id} />
               {light.name}
             </label>
           {/each}

--- a/frontend/src/CreateSceneForm.svelte
+++ b/frontend/src/CreateSceneForm.svelte
@@ -1,0 +1,214 @@
+<script>
+  import { onMount } from 'svelte'
+
+  let { lights, zones, onCreate, onClose } = $props()
+
+  let dialog = $state(null)
+  let name = $state('')
+  let selectedLightIds = $state([])
+  let selectedZoneId = $state('')
+  let submitting = $state(false)
+  let error = $state(null)
+
+  let canSubmit = $derived(name.trim().length > 0 && selectedLightIds.length > 0 && !submitting)
+
+  onMount(() => {
+    dialog?.showModal()
+  })
+
+  function toggleLight(lightId) {
+    selectedLightIds = selectedLightIds.includes(lightId)
+      ? selectedLightIds.filter((id) => id !== lightId)
+      : [...selectedLightIds, lightId]
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    if (!canSubmit) return
+    submitting = true
+    error = null
+    try {
+      await onCreate(name.trim(), selectedLightIds, selectedZoneId || null)
+      dialog?.close()
+    } catch (err) {
+      error = err.message
+      submitting = false
+    }
+  }
+
+  function handleBackdropClick(event) {
+    // A click that lands on the <dialog> element itself (rather than
+    // something inside the <form>) is a click on the backdrop.
+    if (event.target === dialog) {
+      dialog.close()
+    }
+  }
+</script>
+
+<dialog bind:this={dialog} onclose={onClose} onclick={handleBackdropClick}>
+  <form onsubmit={handleSubmit}>
+    <h2>New Scene</h2>
+
+    <label class="field">
+      <span>Name</span>
+      <input type="text" bind:value={name} maxlength="32" placeholder="e.g. Movie Night" />
+    </label>
+
+    <fieldset class="field">
+      <legend>Lights</legend>
+      {#if lights.length === 0}
+        <p class="hint">No lights available.</p>
+      {:else}
+        <div class="light-list">
+          {#each lights as light (light.id)}
+            <label class="light-option">
+              <input
+                type="checkbox"
+                checked={selectedLightIds.includes(light.id)}
+                onchange={() => toggleLight(light.id)}
+              />
+              {light.name}
+            </label>
+          {/each}
+        </div>
+      {/if}
+    </fieldset>
+
+    <label class="field">
+      <span>Zone</span>
+      <select bind:value={selectedZoneId}>
+        <option value="">No zone</option>
+        {#each zones as zone (zone.id)}
+          <option value={zone.id}>{zone.name}</option>
+        {/each}
+      </select>
+    </label>
+
+    {#if selectedZoneId}
+      <p class="hint">
+        This scene will capture every light currently in this zone — the light selection above
+        is ignored once a zone is set.
+      </p>
+    {/if}
+
+    {#if error}
+      <p class="error">{error}</p>
+    {/if}
+
+    <div class="actions">
+      <button type="button" onclick={() => dialog?.close()}>Cancel</button>
+      <button type="submit" class="primary" disabled={!canSubmit}>
+        {submitting ? 'Creating…' : 'Create Scene'}
+      </button>
+    </div>
+  </form>
+</dialog>
+
+<style>
+  dialog {
+    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+    background: light-dark(#fff, #1e1e1e);
+    color: inherit;
+    width: min(24rem, 90vw);
+  }
+
+  dialog::backdrop {
+    background: rgba(0, 0, 0, 0.4);
+  }
+
+  h2 {
+    margin: 0 0 1rem;
+    font-size: 1.1rem;
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .field > span,
+  .field legend {
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0;
+  }
+
+  input[type='text'],
+  select {
+    font: inherit;
+    padding: 0.4rem 0.5rem;
+    border-radius: 0.5rem;
+    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    background: light-dark(#fff, #262626);
+    color: inherit;
+  }
+
+  .light-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    max-height: 10rem;
+    overflow-y: auto;
+    padding: 0.5rem;
+    border-radius: 0.5rem;
+    background: light-dark(#f7f7f7, #262626);
+  }
+
+  .light-option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  .hint {
+    font-size: 0.8rem;
+    color: light-dark(#666, #aaa);
+    margin: 0;
+  }
+
+  .error {
+    font-size: 0.85rem;
+    color: light-dark(#a3392c, #f0958a);
+    margin: 0;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  button {
+    font: inherit;
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    background: light-dark(#eee, #333);
+    color: inherit;
+    cursor: pointer;
+  }
+
+  button.primary {
+    background: light-dark(#1c7a2e, #1f3d24);
+    color: light-dark(#fff, #7fe396);
+    border-color: transparent;
+  }
+
+  button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>


### PR DESCRIPTION
## Summary

Closes #10

- Adds `POST /api/scenes` (`backend/app/hue_client.py`: `create_scene`, `get_group_light_count`; `backend/app/main.py`: `SceneCreateRequest`, route) to create a scene from the current live state of selected lights.
- Adds `frontend/src/CreateSceneForm.svelte` — a native `<dialog>`-based form (no new dependency) with a scene-name input, a checkbox list of lights, and an optional zone `<select>`. Wired into a new "+ New Scene" button in the Scenes section header of `App.svelte`.
- Updates `backend/HUE_API.md` with a new "Creating a scene" section documenting what was confirmed live (this endpoint had no prior documentation).

## What was confirmed against the real bridge (required research before writing the route)

Ran a throwaway script against the real paired bridge (using this worktree's gitignored `backend/config.yaml`, never committed) to determine the actual `POST /api/<username>/scenes` shape, since `HUE_API.md` had a genuine gap here:

- **Standalone `LightScene`**: `{"name", "lights": [...], "recycle": false, "type": "LightScene"}`. `lights` is required and non-empty; omitting it returns error type 5. `type` can be omitted (defaults to `LightScene`) but is sent explicitly for clarity.
- **`GroupScene`**: `{"name", "recycle": false, "type": "GroupScene", "group": "<id>"}` — **critically, `lights` must be entirely omitted**. Including it alongside `group` (even matching the group's own members exactly) is rejected with `{"error": {"type": 14, "description": "Conflicting parameter, type: GroupScenes"}}`. A GroupScene's membership is derived solely from the group at creation time — confirmed by creating one and fetching it back: its `lights` field always equals every light currently in that group, regardless of what (if anything) was requested.
  - This meant the light-checkbox picker in the form is only meaningful for a standalone scene — once a zone is picked, the created scene always captures every light in that zone. The form shows an inline note explaining this when a zone is selected. The backend route also can't synthesize an accurate `light_count` from the submitted `light_ids` in the GroupScene case, so it fetches the group's actual light count after creation (one extra bridge call, only for that path) rather than trusting the request body.
- **Name length cap**: exactly 32 characters (binary-tested 32 vs. 33 against the real bridge — 33 is rejected with error type 7).
- **No target values**: the create body has no way to set target on/bri/color — a scene always snapshots the involved lights' *current* live state (confirmed via `GET /scenes/<id>` immediately after creation).
- Response shape matches the existing write-response handling: `[{"success": {"id": "<new-id>"}}]` / error list.
- Test scenes created during this research were deleted from the bridge afterward.

## Test plan

- [x] `cd backend && pytest` — 25 passed (5 new tests in `test_scene_create.py`: GroupScene body/response shape incl. accurate `light_count` via a mocked `GET /groups/<id>`, LightScene body/response shape, empty name → 422, empty `light_ids` → 422, bridge error list → 502).
- [x] `cd frontend && npm run build` — succeeds, no errors.
- [x] Live smoke test via `make dev` against the real bridge (Chrome browser automation): opened the form, created a standalone scene with 2 lights checked and no zone → appeared under "Other" with "2 lights"; created a second scene with a zone selected → appeared under that zone's group with the zone's actual light count (6), not the 1 light that was checked, confirming the GroupScene light-count fetch works end-to-end. Both test scenes were deleted from the bridge afterward, and the dev servers were stopped.