### PR TITLE
Frontend: per-bulb on/off toggle

### DIFF
--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -313,6 +313,17 @@ async def create_scene(
     return result[0]["success"]["id"]
 
 
+async def set_light_state(
+    config: BridgeConfig, light_id: str, *, on: Optional[bool] = None, brightness_pct: Optional[int] = None
+) -> None:
+    body = {}
+    if on is not None:
+        body["on"] = on
+    if brightness_pct is not None:
+        body["bri"] = _pct_to_bri(brightness_pct)
+    await _bridge_request(config, f"lights/{light_id}/state", method="PUT", json_body=body)
+
+
 async def get_group_light_count(config: BridgeConfig, group_id: str) -> int:
     """Light count for a single group.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import Optional
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator
@@ -18,6 +18,7 @@ from app.hue_client import (
     get_lights,
     get_scenes,
     get_zones,
+    set_light_state,
 )
 
 app = FastAPI(title="Hue Light Control API")
@@ -50,6 +51,22 @@ def health():
 async def list_lights() -> list[Light]:
     config = load_config()
     return await get_lights(config)
+
+
+class LightStateUpdate(BaseModel):
+    on: Optional[bool] = None
+    # 0 isn't a settable target (that's what on: false is for) — matches
+    # _pct_to_bri's floor of 1.
+    brightness_pct: Optional[int] = Field(default=None, ge=1, le=100)
+
+
+@app.put("/api/lights/{light_id}/state")
+async def update_light_state(light_id: str, update: LightStateUpdate):
+    if update.on is None and update.brightness_pct is None:
+        raise HTTPException(status_code=400, detail="must set on and/or brightness_pct")
+    config = load_config()
+    await set_light_state(config, light_id, on=update.on, brightness_pct=update.brightness_pct)
+    return {"status": "ok"}
 
 
 @app.get("/api/scenes")

--- a/backend/tests/test_light_routes.py
+++ b/backend/tests/test_light_routes.py
@@ -1,0 +1,95 @@
+import json
+
+import respx
+from httpx import Response
+
+BRIDGE_URL = "http://192.168.x.x/api/test-api-key"
+
+
+@respx.mock
+async def test_set_light_on(client):
+    state_route = respx.put(f"{BRIDGE_URL}/lights/1/state").mock(
+        return_value=Response(200, json=[{"success": {"/lights/1/state/on": True}}])
+    )
+
+    resp = await client.put("/api/lights/1/state", json={"on": True})
+
+    assert resp.status_code == 200
+    assert json.loads(state_route.calls.last.request.content) == {"on": True}
+
+
+@respx.mock
+async def test_set_light_off(client):
+    state_route = respx.put(f"{BRIDGE_URL}/lights/1/state").mock(
+        return_value=Response(200, json=[{"success": {"/lights/1/state/on": False}}])
+    )
+
+    resp = await client.put("/api/lights/1/state", json={"on": False})
+
+    assert resp.status_code == 200
+    assert json.loads(state_route.calls.last.request.content) == {"on": False}
+
+
+@respx.mock
+async def test_set_light_brightness(client):
+    state_route = respx.put(f"{BRIDGE_URL}/lights/1/state").mock(
+        return_value=Response(200, json=[{"success": {"/lights/1/state/bri": 127}}])
+    )
+
+    resp = await client.put("/api/lights/1/state", json={"brightness_pct": 50})
+
+    assert resp.status_code == 200
+    assert json.loads(state_route.calls.last.request.content) == {"bri": 127}
+
+
+@respx.mock
+async def test_set_light_on_and_brightness(client):
+    state_route = respx.put(f"{BRIDGE_URL}/lights/1/state").mock(
+        return_value=Response(
+            200, json=[{"success": {"/lights/1/state/on": True}}, {"success": {"/lights/1/state/bri": 127}}]
+        )
+    )
+
+    resp = await client.put("/api/lights/1/state", json={"on": True, "brightness_pct": 50})
+
+    assert resp.status_code == 200
+    assert json.loads(state_route.calls.last.request.content) == {"on": True, "bri": 127}
+
+
+async def test_set_light_state_neither_field_is_400(client):
+    resp = await client.put("/api/lights/1/state", json={})
+
+    assert resp.status_code == 400
+
+
+async def test_set_light_state_brightness_zero_is_422(client):
+    resp = await client.put("/api/lights/1/state", json={"brightness_pct": 0})
+
+    assert resp.status_code == 422
+
+
+async def test_set_light_state_brightness_too_high_is_422(client):
+    resp = await client.put("/api/lights/1/state", json={"brightness_pct": 101})
+
+    assert resp.status_code == 422
+
+
+@respx.mock
+async def test_set_light_state_bridge_error_returns_502(client):
+    respx.put(f"{BRIDGE_URL}/lights/1/state").mock(
+        return_value=Response(200, json=[{"error": {"description": "parameter not available"}}])
+    )
+
+    resp = await client.put("/api/lights/1/state", json={"on": True})
+
+    assert resp.status_code == 502
+
+
+async def test_set_light_state_bridge_not_configured_returns_503(client, monkeypatch):
+    from app.config import BridgeConfig
+
+    monkeypatch.setattr("app.main.load_config", lambda: BridgeConfig())
+
+    resp = await client.put("/api/lights/1/state", json={"on": True})
+
+    assert resp.status_code == 503

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -73,15 +73,24 @@
     return [...byId.values(), other].filter((group) => group.scenes.length > 0)
   })
 
+  // Note: a bridge write can succeed here (200) for a light that's
+  // temporarily unreachable — Hue queues state changes for offline Zigbee
+  // devices rather than rejecting them. In that case the optimistic value
+  // below sticks even though the bulb hasn't physically changed yet; it
+  // reconciles on the next /api/lights refetch. Not gating the toggle on
+  // reachable is intentional (see LightCard) — this staleness window is an
+  // accepted tradeoff of that.
   async function toggleLight(lightId, on) {
     const light = lights.find((l) => l.id === lightId)
     if (!light) return
     const prev = light.on
     light.on = on
+    light.toggleError = null
     try {
       await putJson(`/api/lights/${lightId}/state`, { on })
-    } catch {
+    } catch (err) {
       light.on = prev
+      light.toggleError = err.message
     }
   }
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -3,7 +3,7 @@
   import LightCard from './LightCard.svelte'
   import SceneCard from './SceneCard.svelte'
   import CreateSceneForm from './CreateSceneForm.svelte'
-  import { fetchJson, postJson } from './api.js'
+  import { fetchJson, postJson, putJson } from './api.js'
 
   let lights = $state([])
   let lightsLoading = $state(true)
@@ -73,6 +73,18 @@
     return [...byId.values(), other].filter((group) => group.scenes.length > 0)
   })
 
+  async function toggleLight(lightId, on) {
+    const light = lights.find((l) => l.id === lightId)
+    if (!light) return
+    const prev = light.on
+    light.on = on
+    try {
+      await putJson(`/api/lights/${lightId}/state`, { on })
+    } catch {
+      light.on = prev
+    }
+  }
+
   let showCreateForm = $state(false)
 
   async function createScene(name, lightIds, groupId) {
@@ -96,7 +108,7 @@
     {:else}
       <div class="grid">
         {#each lights as light (light.id)}
-          <LightCard {light} />
+          <LightCard {light} onToggle={toggleLight} />
         {/each}
       </div>
     {/if}

--- a/frontend/src/LightCard.svelte
+++ b/frontend/src/LightCard.svelte
@@ -1,5 +1,5 @@
 <script>
-  let { light } = $props()
+  let { light, onToggle } = $props()
 </script>
 
 <div class="card" class:unreachable={!light.reachable}>
@@ -12,7 +12,14 @@
   </div>
 
   <div class="status">
-    <span class="badge" class:on={light.on}>{light.on ? 'On' : 'Off'}</span>
+    <button
+      type="button"
+      class="badge toggle"
+      class:on={light.on}
+      onclick={() => onToggle(light.id, !light.on)}
+    >
+      {light.on ? 'On' : 'Off'}
+    </button>
     {#if !light.reachable}
       <span class="badge unreachable-badge">Unreachable</span>
     {/if}
@@ -77,6 +84,22 @@
   .badge.on {
     background: light-dark(#dcf5df, #1f3d24);
     color: light-dark(#1c7a2e, #7fe396);
+  }
+
+  .toggle {
+    font: inherit;
+    font-size: 0.75rem;
+    border: none;
+    cursor: pointer;
+  }
+
+  .toggle:hover {
+    filter: brightness(0.95);
+  }
+
+  .toggle:focus-visible {
+    outline: 2px solid light-dark(#1c7a2e, #7fe396);
+    outline-offset: 2px;
   }
 
   .unreachable-badge {

--- a/frontend/src/LightCard.svelte
+++ b/frontend/src/LightCard.svelte
@@ -1,5 +1,21 @@
 <script>
   let { light, onToggle } = $props()
+
+  // Serializes toggle clicks for this card: while a PUT is in flight the
+  // button is disabled, so a fast double-click can't fire a second request
+  // that resolves out of order with the first and leaves the optimistic
+  // on/off state permanently diverged from the bridge.
+  let pending = $state(false)
+
+  async function handleToggle() {
+    if (pending) return
+    pending = true
+    try {
+      await onToggle(light.id, !light.on)
+    } finally {
+      pending = false
+    }
+  }
 </script>
 
 <div class="card" class:unreachable={!light.reachable}>
@@ -16,12 +32,17 @@
       type="button"
       class="badge toggle"
       class:on={light.on}
-      onclick={() => onToggle(light.id, !light.on)}
+      aria-pressed={light.on}
+      disabled={pending}
+      onclick={handleToggle}
     >
       {light.on ? 'On' : 'Off'}
     </button>
     {#if !light.reachable}
       <span class="badge unreachable-badge">Unreachable</span>
+    {/if}
+    {#if light.toggleError}
+      <span class="badge error-badge">{light.toggleError}</span>
     {/if}
   </div>
 
@@ -102,7 +123,13 @@
     outline-offset: 2px;
   }
 
-  .unreachable-badge {
+  .toggle:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  .unreachable-badge,
+  .error-badge {
     background: light-dark(#fbe3e0, #3d211f);
     color: light-dark(#a3392c, #f0958a);
   }


### PR DESCRIPTION
## Summary
- Backend: adds `set_light_state()` in `hue_client.py` and `PUT /api/lights/{light_id}/state` in `main.py`, accepting `on` and/or `brightness_pct` in one body — built generally enough that issue #13 (brightness slider) can reuse the same route without changing it. `brightness_pct` validates `ge=1, le=100` (matches `_pct_to_bri`'s floor of 1; `on: false` is how you go to zero).
- Frontend: `LightCard`'s on/off badge is now a real `<button>` (keyboard accessible), calling a new `onToggle` prop wired up in `App.svelte` as `toggleLight(lightId, on)` — optimistic update with revert-on-failure via `putJson`. Not gated on `light.reachable`, since the bridge queues commands for temporarily-unreachable Zigbee devices.
- No new note added to `HUE_API.md` — `PUT lights/<id>/state` was already documented there (unlike scene creation, nothing undocumented/bridge-quirk-specific was discovered).

## Test plan
- [x] `cd backend && pytest` — 36 passed (8 new tests in `test_light_routes.py`: on, off, brightness, combined, empty body 400, brightness 0/101 → 422, bridge error → 502, bridge not configured → 503)
- [x] `cd frontend && npm run build` — succeeds
- [x] Live smoke test against the real bridge via `make dev`-equivalent (uvicorn + vite): clicked "Chandelier 4"'s Off badge in the browser, confirmed via `GET /api/lights` it flipped to `on: true` on the actual bridge, then toggled it back off and confirmed `on: false` restored. Dev servers stopped afterward.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)