### PR TITLE
Frontend: per-bulb brightness slider

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -94,6 +94,38 @@
     }
   }
 
+  // Same optimistic-update-with-revert pattern as toggleLight. Dragging
+  // brightness up implies the light is on, since a bulb reporting bri>0
+  // while off wouldn't visually reflect the change until turned on.
+  //
+  // Unlike the toggle button, BrightnessSlider isn't disabled while a
+  // request is in flight (that would fight the user mid-drag), so rapid
+  // successive commits can leave overlapping PUTs in flight. Track the
+  // latest request per light and only let a request revert/report an
+  // error if it's still the latest one — otherwise an older request that
+  // fails after a newer one already succeeded would stomp the newer,
+  // already-applied value.
+  const latestBrightnessRequest = new Map()
+
+  async function setLightBrightness(lightId, pct) {
+    const light = lights.find((l) => l.id === lightId)
+    if (!light) return
+    const prev = { on: light.on, brightness_pct: light.brightness_pct }
+    const token = Symbol()
+    latestBrightnessRequest.set(lightId, token)
+    light.brightness_pct = pct
+    light.on = true
+    light.toggleError = null
+    try {
+      await putJson(`/api/lights/${lightId}/state`, { brightness_pct: pct, on: true })
+    } catch (err) {
+      if (latestBrightnessRequest.get(lightId) === token) {
+        Object.assign(light, prev)
+        light.toggleError = err.message
+      }
+    }
+  }
+
   let showCreateForm = $state(false)
 
   async function createScene(name, lightIds, groupId) {
@@ -117,7 +149,7 @@
     {:else}
       <div class="grid">
         {#each lights as light (light.id)}
-          <LightCard {light} onToggle={toggleLight} />
+          <LightCard {light} onToggle={toggleLight} onBrightnessChange={setLightBrightness} />
         {/each}
       </div>
     {/if}

--- a/frontend/src/LightCard.svelte
+++ b/frontend/src/LightCard.svelte
@@ -1,5 +1,7 @@
 <script>
-  let { light, onToggle } = $props()
+  import BrightnessSlider from './BrightnessSlider.svelte'
+
+  let { light, onToggle, onBrightnessChange } = $props()
 
   // Serializes toggle clicks for this card: while a PUT is in flight the
   // button is disabled, so a fast double-click can't fire a second request
@@ -46,12 +48,11 @@
     {/if}
   </div>
 
-  <div class="brightness">
-    <div class="brightness-track">
-      <div class="brightness-fill" style:width="{light.brightness_pct}%"></div>
-    </div>
-    <span class="brightness-label">{light.brightness_pct}%</span>
-  </div>
+  <BrightnessSlider
+    value={light.brightness_pct}
+    label="{light.name} brightness"
+    onChange={(pct) => onBrightnessChange(light.id, pct)}
+  />
 </div>
 
 <style>
@@ -132,31 +133,5 @@
   .error-badge {
     background: light-dark(#fbe3e0, #3d211f);
     color: light-dark(#a3392c, #f0958a);
-  }
-
-  .brightness {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .brightness-track {
-    flex: 1;
-    height: 0.4rem;
-    border-radius: 999px;
-    background: light-dark(#eee, #333);
-    overflow: hidden;
-  }
-
-  .brightness-fill {
-    height: 100%;
-    background: light-dark(#333, #ddd);
-  }
-
-  .brightness-label {
-    font-size: 0.75rem;
-    color: light-dark(#666, #aaa);
-    width: 2.5rem;
-    text-align: right;
   }
 </style>


### PR DESCRIPTION
## Summary

Closes #13

- Wires the existing `BrightnessSlider.svelte` component into `LightCard.svelte`, replacing the static (non-interactive) `.brightness-track`/`.brightness-fill`/`.brightness-label` bar markup, and removes the now-dead CSS for those classes (`BrightnessSlider` is fully self-styled).
- Adds `setLightBrightness(lightId, pct)` in `App.svelte`, following the same optimistic-update-with-revert pattern as the existing `toggleLight`. Dragging brightness also sets `on: true`, since a bulb's `bri` value is only visually meaningful while it's on.
- The slider is intentionally **not** gated on `light.reachable` or `light.on`, consistent with the same reasoning used for the toggle button in #12 (Hue queues writes for unreachable/off Zigbee devices; the `.card.unreachable` dimming is sufficient visual signal).
- Self-review addition: `setLightBrightness` uses a per-light request token so that if a user drags-and-releases rapidly (firing overlapping PUTs), an older request failing after a newer one has already succeeded won't stomp the newer value or show a stale error. (The toggle button avoids this by disabling itself while a request is in flight; the brightness slider intentionally stays interactive during a request so dragging isn't interrupted, so it needed its own guard instead.)

Backend untouched — `set_light_state`/`PUT /api/lights/{id}/state` already supported `brightness_pct` from prior work and is already covered by `backend/tests/test_light_routes.py`.

## Test plan

- [x] `cd backend && .venv/bin/pytest -q` → 36 passed (no backend changes, no regressions)
- [x] `cd frontend && npm run build` → succeeds (one pre-existing, unrelated Svelte compiler warning in `BrightnessSlider.svelte` about `$state` locally-captured reference — not introduced by this change, out of scope)
- [x] Live smoke test via `make dev` against the real bridge (worktree's local `backend/config.yaml`) using Chrome browser automation: dragged the "Bedside Table Lamp" slider from 70% down to 24% in the UI, confirmed via `GET /api/lights` that the physical bridge state updated to `on: true, brightness_pct: 24`, then restored it to its original `on: false, brightness_pct: 70` via the UI toggle and confirmed via the API again. Dev servers stopped afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)