### PR TITLE
Frontend: activate Scenes

### DIFF
--- a/backend/HUE_API.md
+++ b/backend/HUE_API.md
@@ -108,6 +108,28 @@ creating one: `lightstates` matched the lights' actual current state).
 There is no way to create a scene with lights set to values other than
 whatever they're currently at.
 
+### Activating a scene (issue: activate Scenes)
+
+Confirms what the Groups section above already documents: there's no
+scene-specific "activate" endpoint. The app's `POST
+/api/scenes/<id>/activate` route (body: `{"group_id": "<id>", "brightness_pct":
+<1-100, optional>}`) turns around and issues `PUT
+/api/<username>/groups/<group_id>/action` with `{"scene": "<id>"}` — the
+same call the Groups/Scenes sections describe. `group_id` must be supplied
+by the caller (the frontend gets it from the scene's own `group_id`, which
+is null for a standalone `LightScene` — those can't be activated this way
+and the frontend disables them).
+
+Since activation is a PUT (idempotent — resending "activate this scene"
+twice is harmless), it goes through the normal rediscovery-retry path,
+unlike scene creation's POST.
+
+`brightness_pct`, when given, is sent as `bri` in the same body alongside
+`scene`. This combination has **not** been verified against a real
+bridge — whether the bridge actually applies both, or silently drops one,
+is unconfirmed. It's accepted now for forward-compatibility with a future
+per-scene-brightness feature but isn't exercised by the frontend yet.
+
 ## Notes
 
 - This is the CLIP v1 local API (plain HTTP, no cert handling needed), not

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -324,6 +324,27 @@ async def set_light_state(
     await _bridge_request(config, f"lights/{light_id}/state", method="PUT", json_body=body)
 
 
+async def activate_scene(
+    config: BridgeConfig, group_id: str, scene_id: str, brightness_pct: Optional[int] = None
+) -> None:
+    """Activate a scene via its owning group's action endpoint.
+
+    Hue has no dedicated "activate scene" endpoint — scenes are applied by
+    PUTting {"scene": <id>} to the group's action endpoint (see
+    HUE_API.md's Scenes section). This is a PUT, so unlike create_scene's
+    POST it's safe to let it go through the normal rediscovery-retry path:
+    resending "activate this scene" twice is harmless.
+    """
+    body = {"scene": scene_id}
+    if brightness_pct is not None:
+        # Unverified: whether the bridge actually applies `bri` alongside
+        # `scene` in a single call, or silently ignores/overrides one of
+        # them, hasn't been confirmed against a real bridge. If it doesn't
+        # behave as expected, this may need to become two sequential calls.
+        body["bri"] = _pct_to_bri(brightness_pct)
+    await _bridge_request(config, f"groups/{group_id}/action", method="PUT", json_body=body)
+
+
 async def get_group_light_count(config: BridgeConfig, group_id: str) -> int:
     """Light count for a single group.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.hue_client import (
     Light,
     Scene,
     Zone,
+    activate_scene,
     create_scene,
     get_group_light_count,
     get_lights,
@@ -115,3 +116,18 @@ async def create_scene_route(body: SceneCreateRequest) -> Scene:
         scene_id = await create_scene(config, body.name, body.light_ids, body.group_id)
         light_count = len(body.light_ids)
     return Scene(id=scene_id, name=body.name, light_count=light_count, group_id=body.group_id)
+
+
+class SceneActivateRequest(BaseModel):
+    group_id: str
+    # Accepted now for forward-compatibility with per-scene brightness; not
+    # wired up in the frontend yet. See activate_scene's docstring for the
+    # unverified combined-body behavior this relies on.
+    brightness_pct: Optional[int] = Field(default=None, ge=1, le=100)
+
+
+@app.post("/api/scenes/{scene_id}/activate")
+async def activate_scene_route(scene_id: str, body: SceneActivateRequest):
+    config = load_config()
+    await activate_scene(config, body.group_id, scene_id, brightness_pct=body.brightness_pct)
+    return {"status": "ok"}

--- a/backend/tests/test_scene_routes.py
+++ b/backend/tests/test_scene_routes.py
@@ -1,0 +1,63 @@
+import json
+
+import respx
+from httpx import Response
+
+BRIDGE_URL = "http://192.168.x.x/api/test-api-key"
+
+
+@respx.mock
+async def test_activate_scene(client):
+    action_route = respx.put(f"{BRIDGE_URL}/groups/g1/action").mock(
+        return_value=Response(200, json=[{"success": {"/groups/g1/action/scene": "abc123"}}])
+    )
+
+    resp = await client.post("/api/scenes/abc123/activate", json={"group_id": "g1"})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    assert json.loads(action_route.calls.last.request.content) == {"scene": "abc123"}
+
+
+async def test_activate_scene_missing_group_id_is_422(client):
+    resp = await client.post("/api/scenes/abc123/activate", json={})
+
+    assert resp.status_code == 422
+
+
+@respx.mock
+async def test_activate_scene_with_brightness_includes_bri(client):
+    action_route = respx.put(f"{BRIDGE_URL}/groups/g1/action").mock(
+        return_value=Response(200, json=[{"success": {"/groups/g1/action/scene": "abc123"}}])
+    )
+
+    resp = await client.post(
+        "/api/scenes/abc123/activate", json={"group_id": "g1", "brightness_pct": 50}
+    )
+
+    assert resp.status_code == 200
+    # Matches the current unverified single-call implementation (see
+    # HUE_API.md's "Activating a scene" section) — combining scene+bri in
+    # one body is not confirmed against a real bridge and may change.
+    assert json.loads(action_route.calls.last.request.content) == {"scene": "abc123", "bri": 127}
+
+
+@respx.mock
+async def test_activate_scene_bridge_error_returns_502(client):
+    respx.put(f"{BRIDGE_URL}/groups/g1/action").mock(
+        return_value=Response(200, json=[{"error": {"description": "invalid/missing parameters in body"}}])
+    )
+
+    resp = await client.post("/api/scenes/abc123/activate", json={"group_id": "g1"})
+
+    assert resp.status_code == 502
+
+
+async def test_activate_scene_bridge_not_configured_returns_503(client, monkeypatch):
+    from app.config import BridgeConfig
+
+    monkeypatch.setattr("app.main.load_config", lambda: BridgeConfig())
+
+    resp = await client.post("/api/scenes/abc123/activate", json={"group_id": "g1"})
+
+    assert resp.status_code == 503

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -132,6 +132,21 @@
     const scene = await postJson('/api/scenes', { name, light_ids: lightIds, group_id: groupId })
     scenes = [...scenes, scene]
   }
+
+  // Unlike toggleLight, there's no meaningful "prior value" to optimistically
+  // set and revert for a one-shot action like activating a scene — just
+  // surface a per-card error on failure. SceneCard guards against overlapping
+  // double-click requests itself (same pattern as LightCard's toggle button).
+  async function activateScene(sceneId, groupId) {
+    const scene = scenes.find((s) => s.id === sceneId)
+    if (!scene) return
+    scene.activateError = null
+    try {
+      await postJson(`/api/scenes/${sceneId}/activate`, { group_id: groupId })
+    } catch (err) {
+      scene.activateError = err.message
+    }
+  }
 </script>
 
 <main>
@@ -187,7 +202,7 @@
           <h3>{group.name}</h3>
           <div class="grid">
             {#each group.scenes as scene (scene.id)}
-              <SceneCard {scene} />
+              <SceneCard {scene} onActivate={activateScene} />
             {/each}
           </div>
         </div>

--- a/frontend/src/SceneCard.svelte
+++ b/frontend/src/SceneCard.svelte
@@ -1,11 +1,42 @@
 <script>
-  let { scene } = $props()
+  let { scene, onActivate } = $props()
+
+  // Standalone LightScenes (no group_id) can't be activated via the
+  // group-action endpoint (see HUE_API.md's Scenes section) — render them
+  // as non-interactive instead of wiring up a click handler.
+  let activatable = $derived(scene.group_id != null)
+
+  // Serializes activation clicks for this card, same reasoning as
+  // LightCard's toggle button: while a request is in flight the button is
+  // disabled, so a fast double-click can't fire a second overlapping
+  // activate request.
+  let pending = $state(false)
+
+  async function handleActivate() {
+    if (pending || !activatable) return
+    pending = true
+    try {
+      await onActivate(scene.id, scene.group_id)
+    } finally {
+      pending = false
+    }
+  }
 </script>
 
-<div class="card">
+<button
+  type="button"
+  class="card"
+  class:inactive={!activatable}
+  disabled={!activatable || pending}
+  title={activatable ? undefined : "Can't activate — not part of a zone"}
+  onclick={handleActivate}
+>
   <span class="name">{scene.name}</span>
   <span class="badge">{scene.light_count} {scene.light_count === 1 ? 'light' : 'lights'}</span>
-</div>
+  {#if scene.activateError}
+    <span class="badge error-badge">{scene.activateError}</span>
+  {/if}
+</button>
 
 <style>
   .card {
@@ -16,6 +47,28 @@
     flex-direction: column;
     gap: 0.6rem;
     background: light-dark(#fff, #1e1e1e);
+    width: 100%;
+    font: inherit;
+    text-align: left;
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .card:hover:not(:disabled) {
+    filter: brightness(0.97);
+  }
+
+  .card:focus-visible {
+    outline: 2px solid light-dark(#1c7a2e, #7fe396);
+    outline-offset: 2px;
+  }
+
+  .card:disabled {
+    cursor: default;
+  }
+
+  .card.inactive {
+    opacity: 0.55;
   }
 
   .name {
@@ -29,5 +82,10 @@
     background: light-dark(#eee, #333);
     color: light-dark(#555, #ccc);
     width: fit-content;
+  }
+
+  .error-badge {
+    background: light-dark(#fbe3e0, #3d211f);
+    color: light-dark(#a3392c, #f0958a);
   }
 </style>


### PR DESCRIPTION
## Summary
- Backend: `POST /api/scenes/{scene_id}/activate` (body: `{"group_id": "<id>", "brightness_pct": <1-100, optional>}`), which PUTs `{"scene": "<id>"}` (plus `bri` if `brightness_pct` given) to the owning group's `groups/{group_id}/action` endpoint — Hue has no dedicated scene-activate endpoint. Since it's a PUT, it goes through the normal rediscovery-retry path (unlike scene creation's POST).
- `activate_scene()` in `hue_client.py` accepts `brightness_pct` for forward-compat with the upcoming per-scene-brightness issue, but the combined `scene`+`bri` body is unverified against a real bridge — noted in a comment and in `HUE_API.md`.
- Frontend: `SceneCard.svelte` is now a real `<button>` — clicking (or Enter/Space) calls `onActivate(scene.id, scene.group_id)`. Standalone `LightScene`s (`group_id: null`, can't be activated via the group-action endpoint) render disabled, dimmed, with an explanatory `title`. Per-card `pending` state guards against overlapping double-click requests, matching the pattern used for the light toggle button. Activation errors surface as a badge on the card (`scene.activateError`), set/cleared in `App.svelte`'s new `activateScene` handler.
- `HUE_API.md` gets a new "Activating a scene" section, matching the style of the existing "Creating a scene" section.

Closes #11

## Test plan
- [x] `cd backend && .venv/bin/pytest -q` — 41 passed (36 existing + 5 new in `test_scene_routes.py`: success PUT body, missing `group_id` → 422, `brightness_pct` includes `bri`, bridge error → 502, bridge not configured → 503).
- [x] `cd frontend && npm run build` — succeeds (pre-existing unrelated Svelte warning in `BrightnessSlider.svelte`, not touched here).
- [x] Live smoke test via `make dev` against the real bridge (worktree's local `backend/config.yaml`): used Chrome automation to click the "Blood moon" scene (zone "All Color Lights") in the running UI, then diffed `/api/lights` before/after — all 7 lights in that zone changed color/brightness as expected, confirming the click reaches the real bridge and activates the scene. Dev servers stopped afterward.
- [x] Self-review pass on the diff (race conditions, error/loading UI, accessibility, `group_id: null` disabled-state clarity) — see notes below.

## Self-review notes
- Used a native `<button disabled>` for the inactive (`group_id: null`) state instead of manual `role`/`tabindex`/`keydown` wiring — gets correct keyboard/focus/screen-reader semantics for free and for the activatable case too (Enter/Space "just work").
- `pending` is local to `SceneCard`, not lifted to `App.svelte` — mirrors `LightCard`'s toggle-button pattern, and keeps the double-click guard co-located with the button it protects.
- No standalone `LightScene`s currently exist on the real bridge to screenshot the disabled state against, but the `group_id != null` logic is simple/direct and covered implicitly by the `Scene` model's existing `group_id: Optional[str]`.