### PR TITLE
Frontend: per-scene brightness slider

### DIFF
--- a/backend/HUE_API.md
+++ b/backend/HUE_API.md
@@ -124,11 +124,22 @@ Since activation is a PUT (idempotent — resending "activate this scene"
 twice is harmless), it goes through the normal rediscovery-retry path,
 unlike scene creation's POST.
 
-`brightness_pct`, when given, is sent as `bri` in the same body alongside
-`scene`. This combination has **not** been verified against a real
-bridge — whether the bridge actually applies both, or silently drops one,
-is unconfirmed. It's accepted now for forward-compatibility with a future
-per-scene-brightness feature but isn't exercised by the frontend yet.
+`brightness_pct`, when given, requires a **second** sequential PUT — confirmed
+against a real bridge. Sending `{"scene": "<id>", "bri": <N>}` in a single
+call reports `"success"` for both fields, but the scene recall wins: every
+light in the group ends up at whatever brightness the scene itself stored,
+silently ignoring the requested `bri`. Getting the requested brightness to
+actually apply requires two sequential PUTs to the same
+`groups/<group_id>/action` endpoint:
+
+1. `{"scene": "<id>"}` — recall the scene.
+2. `{"bri": <N>}` — scale whatever's now on in the group to the requested
+   brightness.
+
+This powers the frontend's per-scene brightness slider: moving the slider
+and releasing it re-activates the scene at that brightness in one user
+action (no live-adjustment of an already-active scene, and no brightness
+state tracked for a scene between activations).
 
 ## Notes
 

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -334,15 +334,23 @@ async def activate_scene(
     HUE_API.md's Scenes section). This is a PUT, so unlike create_scene's
     POST it's safe to let it go through the normal rediscovery-retry path:
     resending "activate this scene" twice is harmless.
+
+    Confirmed against a real bridge: combining {"scene": id, "bri": N} in a
+    single PUT does NOT scale the scene to N — the bridge reports "success"
+    for both fields, but the scene recall wins and each light ends up at
+    whatever brightness the scene itself stored, ignoring the requested
+    `bri`. Getting the requested brightness to actually apply requires two
+    sequential PUTs: first recall the scene, then a second PUT to scale
+    whatever's now on in the group to the requested `bri`.
     """
-    body = {"scene": scene_id}
+    await _bridge_request(config, f"groups/{group_id}/action", method="PUT", json_body={"scene": scene_id})
     if brightness_pct is not None:
-        # Unverified: whether the bridge actually applies `bri` alongside
-        # `scene` in a single call, or silently ignores/overrides one of
-        # them, hasn't been confirmed against a real bridge. If it doesn't
-        # behave as expected, this may need to become two sequential calls.
-        body["bri"] = _pct_to_bri(brightness_pct)
-    await _bridge_request(config, f"groups/{group_id}/action", method="PUT", json_body=body)
+        await _bridge_request(
+            config,
+            f"groups/{group_id}/action",
+            method="PUT",
+            json_body={"bri": _pct_to_bri(brightness_pct)},
+        )
 
 
 async def get_group_light_count(config: BridgeConfig, group_id: str) -> int:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -120,9 +120,10 @@ async def create_scene_route(body: SceneCreateRequest) -> Scene:
 
 class SceneActivateRequest(BaseModel):
     group_id: str
-    # Accepted now for forward-compatibility with per-scene brightness; not
-    # wired up in the frontend yet. See activate_scene's docstring for the
-    # unverified combined-body behavior this relies on.
+    # Wired up in the frontend as the per-scene brightness slider (scale-
+    # on-activate: moving the slider re-activates the scene at that
+    # brightness). See activate_scene's docstring for the confirmed
+    # two-PUT behavior this relies on.
     brightness_pct: Optional[int] = Field(default=None, ge=1, le=100)
 
 

--- a/backend/tests/test_scene_routes.py
+++ b/backend/tests/test_scene_routes.py
@@ -26,9 +26,12 @@ async def test_activate_scene_missing_group_id_is_422(client):
 
 
 @respx.mock
-async def test_activate_scene_with_brightness_includes_bri(client):
+async def test_activate_scene_with_brightness_sends_two_sequential_puts(client):
     action_route = respx.put(f"{BRIDGE_URL}/groups/g1/action").mock(
-        return_value=Response(200, json=[{"success": {"/groups/g1/action/scene": "abc123"}}])
+        side_effect=[
+            Response(200, json=[{"success": {"/groups/g1/action/scene": "abc123"}}]),
+            Response(200, json=[{"success": {"/groups/g1/action/bri": 127}}]),
+        ]
     )
 
     resp = await client.post(
@@ -36,10 +39,32 @@ async def test_activate_scene_with_brightness_includes_bri(client):
     )
 
     assert resp.status_code == 200
-    # Matches the current unverified single-call implementation (see
-    # HUE_API.md's "Activating a scene" section) — combining scene+bri in
-    # one body is not confirmed against a real bridge and may change.
-    assert json.loads(action_route.calls.last.request.content) == {"scene": "abc123", "bri": 127}
+    # Confirmed against a real bridge (see HUE_API.md's "Activating a
+    # scene" section): a single PUT combining scene+bri lets the scene's
+    # own stored brightness win, silently ignoring the requested bri. Two
+    # sequential PUTs — recall, then scale — are required instead.
+    assert action_route.call_count == 2
+    assert json.loads(action_route.calls[0].request.content) == {"scene": "abc123"}
+    assert json.loads(action_route.calls[1].request.content) == {"bri": 127}
+
+
+@respx.mock
+async def test_activate_scene_with_brightness_second_put_error_returns_502(client):
+    # The scene recall (first PUT) succeeds but the brightness scale
+    # (second PUT) is rejected — the whole request should still surface as
+    # an error, not a silent partial success.
+    respx.put(f"{BRIDGE_URL}/groups/g1/action").mock(
+        side_effect=[
+            Response(200, json=[{"success": {"/groups/g1/action/scene": "abc123"}}]),
+            Response(200, json=[{"error": {"description": "invalid/missing parameters in body"}}]),
+        ]
+    )
+
+    resp = await client.post(
+        "/api/scenes/abc123/activate", json={"group_id": "g1", "brightness_pct": 50}
+    )
+
+    assert resp.status_code == 502
 
 
 @respx.mock

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -137,12 +137,20 @@
   // set and revert for a one-shot action like activating a scene — just
   // surface a per-card error on failure. SceneCard guards against overlapping
   // double-click requests itself (same pattern as LightCard's toggle button).
-  async function activateScene(sceneId, groupId) {
+  //
+  // brightnessPct is optional: plain click-to-activate (issue #11) omits it,
+  // the per-scene brightness slider (issue #14) passes it. There's no
+  // "currently active scene brightness" tracked anywhere — moving the
+  // slider just re-activates the scene at that brightness (see
+  // HUE_API.md's "Activating a scene" section).
+  async function activateScene(sceneId, groupId, brightnessPct) {
     const scene = scenes.find((s) => s.id === sceneId)
     if (!scene) return
     scene.activateError = null
     try {
-      await postJson(`/api/scenes/${sceneId}/activate`, { group_id: groupId })
+      const body =
+        brightnessPct == null ? { group_id: groupId } : { group_id: groupId, brightness_pct: brightnessPct }
+      await postJson(`/api/scenes/${sceneId}/activate`, body)
     } catch (err) {
       scene.activateError = err.message
     }

--- a/frontend/src/SceneCard.svelte
+++ b/frontend/src/SceneCard.svelte
@@ -1,4 +1,6 @@
 <script>
+  import BrightnessSlider from './BrightnessSlider.svelte'
+
   let { scene, onActivate } = $props()
 
   // Standalone LightScenes (no group_id) can't be activated via the
@@ -6,37 +8,57 @@
   // as non-interactive instead of wiring up a click handler.
   let activatable = $derived(scene.group_id != null)
 
-  // Serializes activation clicks for this card, same reasoning as
-  // LightCard's toggle button: while a request is in flight the button is
-  // disabled, so a fast double-click can't fire a second overlapping
-  // activate request.
+  // Local, ephemeral UI state — there's no concept of "the currently
+  // active scene's brightness" tracked anywhere (scenes aren't stateful
+  // like that in this app). Resets to 100 on reload; that's expected.
+  // Moving the slider re-activates the scene at that brightness rather
+  // than live-adjusting an already-active scene.
+  let sceneBrightness = $state(100)
+
+  // Serializes both activation paths (plain click and the brightness
+  // slider) for this card: while a request is in flight both controls are
+  // disabled, so a fast click-then-drag (or vice versa) can't fire a
+  // second overlapping activate request.
   let pending = $state(false)
 
-  async function handleActivate() {
+  async function activate(brightnessPct) {
     if (pending || !activatable) return
     pending = true
     try {
-      await onActivate(scene.id, scene.group_id)
+      await onActivate(scene.id, scene.group_id, brightnessPct)
     } finally {
       pending = false
     }
   }
+
+  function handleBrightnessChange(pct) {
+    sceneBrightness = pct
+    activate(pct)
+  }
 </script>
 
-<button
-  type="button"
-  class="card"
-  class:inactive={!activatable}
-  disabled={!activatable || pending}
-  title={activatable ? undefined : "Can't activate — not part of a zone"}
-  onclick={handleActivate}
->
-  <span class="name">{scene.name}</span>
-  <span class="badge">{scene.light_count} {scene.light_count === 1 ? 'light' : 'lights'}</span>
-  {#if scene.activateError}
-    <span class="badge error-badge">{scene.activateError}</span>
-  {/if}
-</button>
+<div class="card" class:inactive={!activatable}>
+  <button
+    type="button"
+    class="activate"
+    disabled={!activatable || pending}
+    title={activatable ? undefined : "Can't activate — not part of a zone"}
+    onclick={() => activate()}
+  >
+    <span class="name">{scene.name}</span>
+    <span class="badge">{scene.light_count} {scene.light_count === 1 ? 'light' : 'lights'}</span>
+    {#if scene.activateError}
+      <span class="badge error-badge">{scene.activateError}</span>
+    {/if}
+  </button>
+
+  <BrightnessSlider
+    value={sceneBrightness}
+    label="{scene.name} brightness"
+    disabled={!activatable || pending}
+    onChange={handleBrightnessChange}
+  />
+</div>
 
 <style>
   .card {
@@ -48,27 +70,39 @@
     gap: 0.6rem;
     background: light-dark(#fff, #1e1e1e);
     width: 100%;
+  }
+
+  .card.inactive {
+    opacity: 0.55;
+  }
+
+  .activate {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.6rem;
+    width: 100%;
+    border: none;
+    padding: 0;
+    margin: 0;
+    background: none;
     font: inherit;
     text-align: left;
     color: inherit;
     cursor: pointer;
   }
 
-  .card:hover:not(:disabled) {
+  .activate:hover:not(:disabled) {
     filter: brightness(0.97);
   }
 
-  .card:focus-visible {
+  .activate:focus-visible {
     outline: 2px solid light-dark(#1c7a2e, #7fe396);
     outline-offset: 2px;
   }
 
-  .card:disabled {
+  .activate:disabled {
     cursor: default;
-  }
-
-  .card.inactive {
-    opacity: 0.55;
   }
 
   .name {


### PR DESCRIPTION
## Summary

Closes #14.

- Adds a `BrightnessSlider` to each `SceneCard`, wired to a "scale-on-activate" flow: moving the slider and releasing it re-activates the scene at that brightness in one action. There's no live-adjustment of an already-active scene and no brightness state tracked between activations (scenes aren't stateful in this app) — the slider's value is local, ephemeral UI state (`$state(100)`), not lifted into `App.svelte` or the `Scene` model.
- Restructures `SceneCard` from a single outer `<button class="card">` to a non-interactive `<div class="card">` wrapper containing an inner `<button class="activate">` (name/badges, click-to-activate) as a *sibling* of the `<BrightnessSlider>` — avoids nesting an interactive slider inside a button (invalid HTML, would double-fire clicks).
- Extends `App.svelte`'s `activateScene(sceneId, groupId, brightnessPct)` to forward an optional `brightness_pct` to the existing `POST /api/scenes/{id}/activate` route (its request model already accepted this field, unused until now).
- A shared `pending` flag in `SceneCard` now guards both the click-to-activate button and the slider against overlapping in-flight requests, disabling both while a request is outstanding. Both controls are disabled for non-activatable (standalone) scenes, same as before.

## Live-bridge verification (required before finalizing the backend)

`activate_scene`'s combined-body behavior (`{"scene": id, "bri": N}` in one PUT) was flagged unverified. Tested directly against the real paired bridge:

- **Combined single PUT does NOT work as hoped.** The bridge replies with `"success"` for both the `scene` and `bri` fields, but the scene recall wins: every light in the group ends up at whatever brightness the scene itself stored, silently ignoring the requested `bri`.
- **Two sequential PUTs work correctly.** First `{"scene": id}` (recall), then a second `{"bri": N}` (scale) to the same `groups/{id}/action` endpoint reliably lands every light at the requested brightness.

`activate_scene` in `backend/app/hue_client.py` was changed to issue two sequential PUTs, and `backend/HUE_API.md`'s "Activating a scene" section was updated with these confirmed findings (replacing the "unverified" language). `backend/tests/test_scene_routes.py` was updated to assert the two-call shape, plus a new test for the second-PUT-failure case (scene recalls successfully but the brightness scale is rejected — should still surface as a 502, not a silent partial success).

## Test plan

- [x] `cd backend && .venv/bin/pytest -q` — 42 passed (was 41; one test updated for the two-PUT shape, one new test added for second-PUT failure)
- [x] `cd frontend && npm run build` — succeeds with no errors
- [x] Live smoke test via `make dev` against the real bridge, driven with Chrome browser automation:
  - Plain click-to-activate (no brightness) on a scene card still works — verified via `GET /api/lights` that the scene's group recalled correctly.
  - Dragged a scene's brightness slider and released — verified via `GET /api/lights` that the scene activated *and* all lights in that group landed at the requested brightness (49%).
  - No console errors, no nested-interactive-control warnings.
  - Dev servers stopped afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)