### PR TITLE
Frontend visual polish, card cleanup, and live scene brightness

### DIFF
--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -39,6 +39,7 @@ class Scene(BaseModel):
     id: str
     name: str
     light_count: int
+    light_ids: list[str] = []
     group_id: Optional[str] = None
 
 
@@ -248,10 +249,12 @@ async def get_lights(config: BridgeConfig) -> list[Light]:
 
 
 def _to_scene(scene_id: str, raw: dict) -> Scene:
+    light_ids = raw.get("lights", [])
     return Scene(
         id=scene_id,
         name=raw.get("name", f"Scene {scene_id}"),
-        light_count=len(raw.get("lights", [])),
+        light_count=len(light_ids),
+        light_ids=light_ids,
         # Only GroupScenes have this; ties the scene to the group (room/zone)
         # it was created for. Absent for standalone LightScenes.
         group_id=raw.get("group"),
@@ -259,6 +262,16 @@ def _to_scene(scene_id: str, raw: dict) -> Scene:
 
 
 async def get_scenes(config: BridgeConfig) -> list[Scene]:
+    # A scene's *stored* brightness (from GET /scenes/<id>'s lightstates)
+    # reflects whatever it looked like when created/last saved — not
+    # whether it's currently applied or what its lights are actually at
+    # right now. There's no bridge concept of "is this scene active" at
+    # all (confirmed: group.action never records which scene, if any, was
+    # last recalled). So this deliberately doesn't fetch per-scene detail —
+    # the frontend instead derives each scene's live on/off + brightness by
+    # matching light_ids against the already-loaded /api/lights, which is
+    # both actually correct (reflects reality, not a stale snapshot) and
+    # cheaper (no per-scene bridge round-trip at all).
     data = await _bridge_request(config, "scenes")
     return [
         _to_scene(scene_id, raw)
@@ -353,11 +366,11 @@ async def activate_scene(
         )
 
 
-async def get_group_light_count(config: BridgeConfig, group_id: str) -> int:
-    """Light count for a single group.
+async def get_group_light_ids(config: BridgeConfig, group_id: str) -> list[str]:
+    """Light ids for a single group.
 
     Used right after creating a GroupScene to report its true membership —
-    see create_scene's docstring for why that isn't simply len(light_ids).
+    see create_scene's docstring for why that isn't simply light_ids.
     """
     data = await _bridge_request(config, f"groups/{group_id}")
-    return len(data.get("lights", []))
+    return data.get("lights", [])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from app.hue_client import (
     Zone,
     activate_scene,
     create_scene,
-    get_group_light_count,
+    get_group_light_ids,
     get_lights,
     get_scenes,
     get_zones,
@@ -104,18 +104,20 @@ async def create_scene_route(body: SceneCreateRequest) -> Scene:
     config = load_config()
     if body.group_id is not None:
         # A GroupScene's membership comes from the group, not light_ids the
-        # caller sent (see create_scene) — fetch the true count rather than
-        # synthesizing a possibly-wrong one from the request body. This
+        # caller sent (see create_scene) — fetch the true membership rather
+        # than synthesizing a possibly-wrong one from the request body. This
         # doesn't depend on the scene-creation result, so run both calls
         # concurrently instead of paying for two round-trips in series.
-        scene_id, light_count = await asyncio.gather(
+        scene_id, light_ids = await asyncio.gather(
             create_scene(config, body.name, body.light_ids, body.group_id),
-            get_group_light_count(config, body.group_id),
+            get_group_light_ids(config, body.group_id),
         )
     else:
         scene_id = await create_scene(config, body.name, body.light_ids, body.group_id)
-        light_count = len(body.light_ids)
-    return Scene(id=scene_id, name=body.name, light_count=light_count, group_id=body.group_id)
+        light_ids = body.light_ids
+    return Scene(
+        id=scene_id, name=body.name, light_count=len(light_ids), light_ids=light_ids, group_id=body.group_id
+    )
 
 
 class SceneActivateRequest(BaseModel):

--- a/backend/tests/test_existing_routes.py
+++ b/backend/tests/test_existing_routes.py
@@ -50,8 +50,12 @@ async def test_list_scenes(client):
     resp = await client.get("/api/scenes")
 
     assert resp.status_code == 200
+    # Deliberately no brightness/on-off here — get_scenes doesn't fetch
+    # per-scene detail at all. The frontend derives live brightness/on-off
+    # by matching light_ids against /api/lights instead, since the bridge
+    # has no concept of "is this scene active" (see hue_client.get_scenes).
     assert resp.json() == [
-        {"id": "s1", "name": "Relax", "light_count": 2, "group_id": "3"},
+        {"id": "s1", "name": "Relax", "light_count": 2, "light_ids": ["1", "2"], "group_id": "3"},
     ]
 
 

--- a/backend/tests/test_scene_create.py
+++ b/backend/tests/test_scene_create.py
@@ -35,6 +35,7 @@ async def test_create_group_scene(client):
         # Reflects the group's actual membership (3 lights), not the 2
         # light_ids that were submitted — those don't apply to a GroupScene.
         "light_count": 3,
+        "light_ids": ["1", "2", "5"],
         "group_id": "3",
     }
 
@@ -58,6 +59,7 @@ async def test_create_light_scene_without_group(client):
         "id": "new456",
         "name": "Reading",
         "light_count": 2,
+        "light_ids": ["1", "2"],
         "group_id": None,
     }
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -37,9 +37,25 @@
   // this is also what keeps a scene's shown brightness from going stale
   // after another scene (or a manual brightness override) changes its
   // lights out from under it.
+  //
+  // Merges into the existing light objects in place rather than replacing
+  // `lights` wholesale: toggleLight/setLightBrightness capture a specific
+  // light object by reference and mutate it on PUT failure to revert/report
+  // an error. If this ran concurrently with one of those and swapped in
+  // fresh objects, a failure arriving afterward would mutate a now-detached
+  // object — invisible to the UI, silently swallowing the revert/error.
   async function refreshLights() {
     try {
-      lights = await fetchJson('/api/lights')
+      const fresh = await fetchJson('/api/lights')
+      const existingById = new Map(lights.map((light) => [light.id, light]))
+      for (const updated of fresh) {
+        const existing = existingById.get(updated.id)
+        if (existing) {
+          Object.assign(existing, updated)
+        } else {
+          lights.push(updated)
+        }
+      }
     } catch {
       // Leave the last-known lights in place; the existing Retry button
       // on the Bulbs section covers a genuinely failing bridge.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -29,6 +29,23 @@
     }
   }
 
+  // Same fetch as loadLights, but silent (no loading-state flicker in the
+  // Bulbs section) — used after a scene activation, since that changes
+  // multiple lights at once on the bridge and the local `lights` array
+  // otherwise has no way to know. Scene cards derive their on/off and
+  // brightness display from this same `lights` array (see SceneCard), so
+  // this is also what keeps a scene's shown brightness from going stale
+  // after another scene (or a manual brightness override) changes its
+  // lights out from under it.
+  async function refreshLights() {
+    try {
+      lights = await fetchJson('/api/lights')
+    } catch {
+      // Leave the last-known lights in place; the existing Retry button
+      // on the Bulbs section covers a genuinely failing bridge.
+    }
+  }
+
   async function loadScenes() {
     scenesLoading = true
     scenesError = null
@@ -151,6 +168,7 @@
       const body =
         brightnessPct == null ? { group_id: groupId } : { group_id: groupId, brightness_pct: brightnessPct }
       await postJson(`/api/scenes/${sceneId}/activate`, body)
+      await refreshLights()
     } catch (err) {
       scene.activateError = err.message
     }
@@ -159,6 +177,7 @@
 
 <main>
   <h1>Hue Light Control</h1>
+  <p class="subtitle">Bulbs and scenes on your local Hue bridge</p>
 
   <section>
     <h2>Bulbs</h2>
@@ -210,7 +229,7 @@
           <h3>{group.name}</h3>
           <div class="grid">
             {#each group.scenes as scene (scene.id)}
-              <SceneCard {scene} onActivate={activateScene} />
+              <SceneCard {scene} {lights} onActivate={activateScene} />
             {/each}
           </div>
         </div>
@@ -220,8 +239,25 @@
 </main>
 
 <style>
-  section + section {
-    margin-top: 2rem;
+  h1 {
+    margin: 0;
+    font-size: 1.75rem;
+    letter-spacing: -0.02em;
+  }
+
+  .subtitle {
+    margin: 0.3rem 0 0;
+    color: light-dark(#666, #999);
+    font-size: 0.95rem;
+  }
+
+  section {
+    margin-top: 2.5rem;
+  }
+
+  section h2 {
+    font-size: 1.15rem;
+    letter-spacing: -0.01em;
   }
 
   .section-header {
@@ -237,18 +273,32 @@
 
   .section-header button {
     font: inherit;
+    font-size: 0.85rem;
+    font-weight: 600;
     padding: 0.4rem 0.9rem;
     border-radius: 999px;
     border: 1px solid light-dark(#d8d8d8, #3a3a3a);
     background: light-dark(#eee, #333);
     color: inherit;
     cursor: pointer;
+    transition: filter 0.15s ease;
+  }
+
+  .section-header button:hover {
+    filter: brightness(0.95);
   }
 
   .grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
     gap: 1rem;
+  }
+
+  .zone-group {
+    border: 1px solid light-dark(#dedede, #333);
+    border-radius: 1rem;
+    background: light-dark(#ebebe9, #1a1a1a);
+    padding: 1.25rem;
   }
 
   .zone-group + .zone-group {
@@ -258,6 +308,7 @@
   .zone-group h3 {
     margin: 0 0 0.75rem;
     font-size: 0.95rem;
+    font-weight: 600;
     color: light-dark(#555, #aaa);
   }
 

--- a/frontend/src/BrightnessSlider.svelte
+++ b/frontend/src/BrightnessSlider.svelte
@@ -1,5 +1,7 @@
 <script>
-  let { value, min = 0, max = 100, disabled = false, label, onChange } = $props()
+  // The bridge (and backend validation) rejects brightness_pct below 1 —
+  // 0 isn't a meaningful "on" brightness, off is the separate toggle.
+  let { value, min = 1, max = 100, disabled = false, showValue = true, label, onChange } = $props()
   let localValue = $state(value)
   $effect(() => { localValue = value })
 </script>
@@ -13,7 +15,9 @@
     aria-label={label}
     onchange={() => onChange(Number(localValue))}
   />
-  <span class="brightness-label">{localValue}%</span>
+  {#if showValue}
+    <span class="brightness-label">{localValue}%</span>
+  {/if}
 </div>
 
 <style>

--- a/frontend/src/CreateSceneForm.svelte
+++ b/frontend/src/CreateSceneForm.svelte
@@ -119,10 +119,19 @@
     background: light-dark(#fff, #1e1e1e);
     color: inherit;
     width: min(24rem, 90vw);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
   }
 
   dialog::backdrop {
     background: rgba(0, 0, 0, 0.4);
+  }
+
+  button.primary:hover:not(:disabled) {
+    filter: brightness(1.08);
+  }
+
+  .actions button:not(.primary):hover {
+    filter: brightness(0.95);
   }
 
   h2 {

--- a/frontend/src/LightCard.svelte
+++ b/frontend/src/LightCard.svelte
@@ -29,6 +29,7 @@
   }
 
   function handleKeydown(event) {
+    if (event.target.closest('.swatch, .slider-wrap')) return
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       handleToggle()

--- a/frontend/src/LightCard.svelte
+++ b/frontend/src/LightCard.svelte
@@ -18,41 +18,61 @@
       pending = false
     }
   }
+
+  // The swatch and brightness slider are their own interactive/decorative
+  // regions, not part of the toggle target — a click that lands in either
+  // (checked via closest, since the slider's range input is what's actually
+  // clicked) shouldn't also toggle the light.
+  function handleCardClick(event) {
+    if (event.target.closest('.swatch, .slider-wrap')) return
+    handleToggle()
+  }
+
+  function handleKeydown(event) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      handleToggle()
+    }
+  }
 </script>
 
-<div class="card" class:unreachable={!light.reachable}>
+<div
+  class="card"
+  class:unreachable={!light.reachable}
+  role="button"
+  tabindex="0"
+  aria-pressed={light.on}
+  aria-disabled={pending}
+  onclick={handleCardClick}
+  onkeydown={handleKeydown}
+>
   <div class="header">
     <span
       class="swatch"
       style:background-color={light.on ? (light.color ?? '#ffe9b3') : undefined}
+      style:box-shadow={light.on ? `0 0 0.5rem ${light.color ?? '#ffe9b3'}` : undefined}
     ></span>
     <span class="name">{light.name}</span>
   </div>
 
-  <div class="status">
-    <button
-      type="button"
-      class="badge toggle"
-      class:on={light.on}
-      aria-pressed={light.on}
-      disabled={pending}
-      onclick={handleToggle}
-    >
-      {light.on ? 'On' : 'Off'}
-    </button>
-    {#if !light.reachable}
-      <span class="badge unreachable-badge">Unreachable</span>
-    {/if}
-    {#if light.toggleError}
-      <span class="badge error-badge">{light.toggleError}</span>
-    {/if}
-  </div>
+  {#if !light.reachable || light.toggleError}
+    <div class="status">
+      {#if !light.reachable}
+        <span class="badge unreachable-badge">Unreachable</span>
+      {/if}
+      {#if light.toggleError}
+        <span class="badge error-badge">{light.toggleError}</span>
+      {/if}
+    </div>
+  {/if}
 
-  <BrightnessSlider
-    value={light.brightness_pct}
-    label="{light.name} brightness"
-    onChange={(pct) => onBrightnessChange(light.id, pct)}
-  />
+  <div class="slider-wrap">
+    <BrightnessSlider
+      value={light.brightness_pct}
+      label="{light.name} brightness"
+      onChange={(pct) => onBrightnessChange(light.id, pct)}
+    />
+  </div>
 </div>
 
 <style>
@@ -64,6 +84,22 @@
     flex-direction: column;
     gap: 0.6rem;
     background: light-dark(#fff, #1e1e1e);
+    box-shadow: 0 1px 2px light-dark(rgba(0, 0, 0, 0.04), rgba(0, 0, 0, 0.2));
+    transition: box-shadow 0.15s ease;
+    cursor: pointer;
+  }
+
+  .card:hover {
+    box-shadow: 0 2px 8px light-dark(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.3));
+  }
+
+  .card:focus-visible {
+    outline: 2px solid light-dark(#1c7a2e, #7fe396);
+    outline-offset: 2px;
+  }
+
+  .card[aria-disabled='true'] {
+    cursor: default;
   }
 
   .card.unreachable {
@@ -83,6 +119,12 @@
     border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.25));
     background: light-dark(#e2e2e2, #2a2a2a);
     flex-shrink: 0;
+    cursor: default;
+    transition: box-shadow 0.2s ease, background-color 0.2s ease;
+  }
+
+  .slider-wrap {
+    cursor: default;
   }
 
   .name {
@@ -101,32 +143,7 @@
     background: light-dark(#eee, #333);
     color: light-dark(#555, #ccc);
     width: fit-content;
-  }
-
-  .badge.on {
-    background: light-dark(#dcf5df, #1f3d24);
-    color: light-dark(#1c7a2e, #7fe396);
-  }
-
-  .toggle {
-    font: inherit;
-    font-size: 0.75rem;
-    border: none;
-    cursor: pointer;
-  }
-
-  .toggle:hover {
-    filter: brightness(0.95);
-  }
-
-  .toggle:focus-visible {
-    outline: 2px solid light-dark(#1c7a2e, #7fe396);
-    outline-offset: 2px;
-  }
-
-  .toggle:disabled {
-    opacity: 0.6;
-    cursor: default;
+    transition: background-color 0.15s ease, color 0.15s ease;
   }
 
   .unreachable-badge,

--- a/frontend/src/SceneCard.svelte
+++ b/frontend/src/SceneCard.svelte
@@ -1,19 +1,38 @@
 <script>
   import BrightnessSlider from './BrightnessSlider.svelte'
 
-  let { scene, onActivate } = $props()
+  let { scene, lights, onActivate } = $props()
 
   // Standalone LightScenes (no group_id) can't be activated via the
   // group-action endpoint (see HUE_API.md's Scenes section) — render them
   // as non-interactive instead of wiring up a click handler.
   let activatable = $derived(scene.group_id != null)
 
-  // Local, ephemeral UI state — there's no concept of "the currently
-  // active scene's brightness" tracked anywhere (scenes aren't stateful
-  // like that in this app). Resets to 100 on reload; that's expected.
-  // Moving the slider re-activates the scene at that brightness rather
-  // than live-adjusting an already-active scene.
-  let sceneBrightness = $state(100)
+  // The bridge has no concept of "is this scene active" or "what's this
+  // scene's current brightness" (confirmed directly against a real bridge —
+  // group.action never records which scene, if any, was last recalled, and
+  // a scene's own stored lightstates reflect creation time, not now). So
+  // rather than asking the bridge, derive both from the same live
+  // /api/lights data the Bulbs section already shows, matched against this
+  // scene's light_ids — that's always accurate and free (no extra
+  // request), and updates automatically whenever `lights` does (a bulb
+  // toggle, or App's refreshLights() after any scene activation).
+  let sceneLights = $derived(lights.filter((light) => scene.light_ids.includes(light.id)))
+  let onLights = $derived(sceneLights.filter((light) => light.on))
+
+  // Only "off" once lights have actually loaded (sceneLights is briefly
+  // empty before that, at which point this stays false, leaving the slider
+  // enabled and at the fallback below rather than flashing "off").
+  let off = $derived(sceneLights.length > 0 && onLights.length === 0)
+
+  // Average brightness across just the on lights, clamped to 1 (the bridge
+  // and BrightnessSlider's min never accept 0). Falls back to 100 while
+  // lights haven't loaded yet, or if the scene isn't on.
+  let liveBrightnessPct = $derived(
+    onLights.length > 0
+      ? Math.max(Math.round(onLights.reduce((sum, light) => sum + light.brightness_pct, 0) / onLights.length), 1)
+      : 100
+  )
 
   // Serializes both activation paths (plain click and the brightness
   // slider) for this card: while a request is in flight both controls are
@@ -30,11 +49,6 @@
       pending = false
     }
   }
-
-  function handleBrightnessChange(pct) {
-    sceneBrightness = pct
-    activate(pct)
-  }
 </script>
 
 <div class="card" class:inactive={!activatable}>
@@ -46,17 +60,17 @@
     onclick={() => activate()}
   >
     <span class="name">{scene.name}</span>
-    <span class="badge">{scene.light_count} {scene.light_count === 1 ? 'light' : 'lights'}</span>
     {#if scene.activateError}
       <span class="badge error-badge">{scene.activateError}</span>
     {/if}
   </button>
 
   <BrightnessSlider
-    value={sceneBrightness}
+    value={liveBrightnessPct}
     label="{scene.name} brightness"
-    disabled={!activatable || pending}
-    onChange={handleBrightnessChange}
+    disabled={!activatable || pending || off}
+    showValue={!off}
+    onChange={activate}
   />
 </div>
 
@@ -70,6 +84,12 @@
     gap: 0.6rem;
     background: light-dark(#fff, #1e1e1e);
     width: 100%;
+    box-shadow: 0 1px 2px light-dark(rgba(0, 0, 0, 0.04), rgba(0, 0, 0, 0.2));
+    transition: box-shadow 0.15s ease;
+  }
+
+  .card:not(.inactive):hover {
+    box-shadow: 0 2px 8px light-dark(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.3));
   }
 
   .card.inactive {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,3 +1,12 @@
+// FastAPI's `detail` is usually a string, but on a 422 it's a list of
+// pydantic error objects ({msg, loc, ...}) — join those into readable text
+// instead of letting `new Error()` stringify the array as "[object Object]".
+function formatDetail(detail) {
+  if (typeof detail === 'string') return detail
+  if (Array.isArray(detail)) return detail.map((e) => e.msg ?? JSON.stringify(e)).join('; ')
+  return undefined
+}
+
 export async function fetchJson(url, options = {}) {
   const { method, body } = options
   const fetchOptions = { method }
@@ -9,7 +18,7 @@ export async function fetchJson(url, options = {}) {
   const res = await fetch(url, fetchOptions)
   if (!res.ok) {
     const parsed = await res.json().catch(() => ({}))
-    throw new Error(parsed.detail ?? `Request failed (${res.status})`)
+    throw new Error(formatDetail(parsed.detail) ?? `Request failed (${res.status})`)
   }
   return res.json()
 }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,11 +1,19 @@
 :root {
   color-scheme: light dark;
-  font-family: system-ui, sans-serif;
+  font-family: -apple-system, system-ui, sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
+  background: light-dark(#f5f5f4, #161616);
+  color: light-dark(#1a1a1a, #ededed);
 }
 
 main {


### PR DESCRIPTION
## Summary
- Visual polish pass: card shadows/hover elevation, dark/light-aware page background, tightened header typography, modal drop shadow
- Fixed a bug where dragging a brightness slider to 0% surfaced a literal `[object Object]` error — sliders now floor at 1%, and `api.js` formats list-shaped validation errors readably as a safety net
- Removed the redundant "n lights" badge from Scene cards and the "On/Off" text badge from Light cards; Light cards are now fully clickable to toggle (except the color swatch and brightness slider)
- Zone groupings now have their own border/background so they read as distinct panels instead of blending into the page
- Scene brightness/on-off is now derived live from `/api/lights` (matched via each scene's `light_ids`) instead of the bridge's static stored scene definition — the bridge has no concept of "is this scene active," so the old approach could go stale after activating another scene. Lights are silently refreshed after every scene activation to keep this in sync. Scenes with all lights off now show a disabled slider with the percentage hidden.

Closes #31, #32, #33, #34, #35

## Test plan
- [x] Backend: `pytest tests/` — 42/42 passing
- [x] Frontend: `npm run build` — clean (only a pre-existing, unrelated Svelte lint warning)
- [x] Manually verified in-browser against a real bridge: card hover/shadow, clickable bulb toggle (swatch/slider excluded), zone panel styling, brightness floor at 1%, off-scene slider disabled/hidden percentage, and the exact stale-brightness repro (drag → activate another scene → reactivate original) now resolves correctly