### PR TITLE
Per-Zone New Scene button

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from typing import Optional
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.config import load_config
 from app.hue_client import (
@@ -86,7 +86,7 @@ class SceneCreateRequest(BaseModel):
     # 32 chars is CLIP v1's actual cap, confirmed against a real bridge
     # (a 33-char name is rejected with error type 7, "invalid value").
     name: str = Field(..., min_length=1, max_length=32)
-    light_ids: list[str] = Field(..., min_length=1)
+    light_ids: list[str] = Field(...)
     group_id: Optional[str] = None
 
     @field_validator("group_id")
@@ -97,6 +97,17 @@ class SceneCreateRequest(BaseModel):
         # rather than passing group="" through to create_scene, which the
         # bridge would reject with an opaque 502.
         return value or None
+
+    @model_validator(mode="after")
+    def _light_ids_required_without_group(self) -> "SceneCreateRequest":
+        # A GroupScene's membership comes entirely from its group — light_ids
+        # is only meaningful (and required) for a standalone LightScene, see
+        # create_scene's docstring. The per-zone "New Scene" button doesn't
+        # collect a light selection at all once a zone is fixed, so this must
+        # accept an empty list whenever group_id is set.
+        if self.group_id is None and not self.light_ids:
+            raise ValueError("light_ids must not be empty when no group_id is given")
+        return self
 
 
 @app.post("/api/scenes", status_code=201)

--- a/backend/tests/test_scene_create.py
+++ b/backend/tests/test_scene_create.py
@@ -100,6 +100,30 @@ async def test_create_scene_empty_light_ids_is_422(client):
 
 
 @respx.mock
+async def test_create_group_scene_with_empty_light_ids(client):
+    # The per-zone "New Scene" button (issue #30) never collects a light
+    # selection — light_ids is irrelevant for a GroupScene anyway (its
+    # membership comes from the group), so an empty list must be accepted
+    # whenever group_id is set.
+    scenes_route = respx.post(f"{BRIDGE_URL}/scenes").mock(
+        return_value=Response(200, json=[{"success": {"id": "new321"}}])
+    )
+    respx.get(f"{BRIDGE_URL}/groups/3").mock(
+        return_value=Response(200, json={"name": "Living Room", "lights": ["1", "2"], "type": "Zone"})
+    )
+
+    resp = await client.post("/api/scenes", json={"name": "Movie Night", "light_ids": [], "group_id": "3"})
+
+    assert resp.status_code == 201
+    assert json.loads(scenes_route.calls.last.request.content) == {
+        "name": "Movie Night",
+        "recycle": False,
+        "type": "GroupScene",
+        "group": "3",
+    }
+
+
+@respx.mock
 async def test_create_scene_bridge_error_returns_502(client):
     respx.post(f"{BRIDGE_URL}/scenes").mock(
         return_value=Response(200, json=[{"error": {"description": "invalid/missing parameters in body"}}])

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -95,15 +95,20 @@
   // Buckets scenes under the zone they belong to. Scenes tied to a Room, an
   // Entertainment area, or no group at all (standalone LightScenes) don't
   // match any zone and land in "Other" — as does every scene if zones failed
-  // to load.
+  // to load. Every real zone is kept even with no scenes yet (isZone: true),
+  // so its "New Scene" button (issue #30) has somewhere to live; "Other"
+  // isn't a real zone (no per-zone create button applies to it) and is
+  // dropped when empty.
   let zoneGroups = $derived.by(() => {
-    const byId = new Map(zones.map((zone) => [zone.id, { id: zone.id, name: zone.name, scenes: [] }]))
-    const other = { id: 'other', name: 'Other', scenes: [] }
+    const byId = new Map(
+      zones.map((zone) => [zone.id, { id: zone.id, name: zone.name, scenes: [], isZone: true }])
+    )
+    const other = { id: 'other', name: 'Other', scenes: [], isZone: false }
     for (const scene of scenes) {
       const group = byId.get(scene.group_id) ?? other
       group.scenes.push(scene)
     }
-    return [...byId.values(), other].filter((group) => group.scenes.length > 0)
+    return [...byId.values(), other].filter((group) => group.isZone || group.scenes.length > 0)
   })
 
   // Note: a bridge write can succeed here (200) for a light that's
@@ -159,7 +164,9 @@
     }
   }
 
-  let showCreateForm = $state(false)
+  // Which zone's "New Scene" dialog is open, if any (issue #30 — one button
+  // per zone rather than a single global one).
+  let createFormZone = $state(null)
 
   async function createScene(name, lightIds, groupId) {
     const scene = await postJson('/api/scenes', { name, light_ids: lightIds, group_id: groupId })
@@ -217,14 +224,14 @@
     <section class="scenes-section">
       <div class="section-header">
         <h2>Scenes</h2>
-        <button onclick={() => (showCreateForm = true)}>+ New Scene</button>
       </div>
-      {#if showCreateForm}
+      {#if createFormZone}
         <CreateSceneForm
           {lights}
           {zones}
+          fixedZone={createFormZone}
           onCreate={createScene}
-          onClose={() => (showCreateForm = false)}
+          onClose={() => (createFormZone = null)}
         />
       {/if}
       {#if scenesLoading || zonesLoading}
@@ -232,8 +239,6 @@
       {:else if scenesError}
         <p class="error">{scenesError}</p>
         <button onclick={loadScenes}>Retry</button>
-      {:else if scenes.length === 0}
-        <p>No scenes found.</p>
       {:else}
         {#if zonesError}
           <p class="error">
@@ -241,14 +246,26 @@
             <button onclick={loadZones}>Retry</button>
           </p>
         {/if}
+        {#if zoneGroups.length === 0}
+          <p>No scenes found.</p>
+        {/if}
         {#each zoneGroups as group (group.id)}
           <div class="zone-group">
             <h3>{group.name}</h3>
-            <div class="grid">
-              {#each group.scenes as scene (scene.id)}
-                <SceneCard {scene} {lights} onActivate={activateScene} />
-              {/each}
-            </div>
+            {#if group.scenes.length === 0}
+              <p class="hint">No scenes in this zone yet.</p>
+            {:else}
+              <div class="grid">
+                {#each group.scenes as scene (scene.id)}
+                  <SceneCard {scene} {lights} onActivate={activateScene} />
+                {/each}
+              </div>
+            {/if}
+            {#if group.isZone}
+              <div class="zone-group-footer">
+                <button onclick={() => (createFormZone = group)}>+ New Scene</button>
+              </div>
+            {/if}
           </div>
         {/each}
       {/if}
@@ -320,7 +337,7 @@
     margin: 0;
   }
 
-  .section-header button {
+  .zone-group-footer button {
     font: inherit;
     font-size: 0.85rem;
     font-weight: 600;
@@ -333,7 +350,7 @@
     transition: filter 0.15s ease;
   }
 
-  .section-header button:hover {
+  .zone-group-footer button:hover {
     filter: brightness(0.95);
   }
 
@@ -359,6 +376,18 @@
     font-size: 0.95rem;
     font-weight: 600;
     color: light-dark(#555, #aaa);
+  }
+
+  .zone-group-footer {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1rem;
+  }
+
+  .hint {
+    font-size: 0.85rem;
+    color: light-dark(#666, #999);
+    margin: 0;
   }
 
   .error {

--- a/frontend/src/CreateSceneForm.svelte
+++ b/frontend/src/CreateSceneForm.svelte
@@ -1,12 +1,16 @@
 <script>
   import { onMount } from 'svelte'
 
-  let { lights, zones, onCreate, onClose } = $props()
+  // fixedZone, when set, pins the scene to that zone (issue #30's per-zone
+  // "New Scene" button) — the zone dropdown and light checkboxes below are
+  // irrelevant in that case, since a zone scene always captures the zone's
+  // actual membership (see the hint text and HUE_API.md).
+  let { lights, zones, fixedZone = null, onCreate, onClose } = $props()
 
   let dialog = $state(null)
   let name = $state('')
   let selectedLightIds = $state([])
-  let selectedZoneId = $state('')
+  let selectedZoneId = $state(fixedZone?.id ?? '')
   let submitting = $state(false)
   let error = $state(null)
 
@@ -58,44 +62,50 @@
 
 <dialog bind:this={dialog} onclose={onClose} onclick={handleBackdropClick}>
   <form onsubmit={handleSubmit}>
-    <h2>New Scene</h2>
+    <h2>{fixedZone ? `New Scene — ${fixedZone.name}` : 'New Scene'}</h2>
 
     <label class="field">
       <span>Name</span>
       <input type="text" bind:value={name} maxlength="32" placeholder="e.g. Movie Night" />
     </label>
 
-    <fieldset class="field">
-      <legend>Lights</legend>
-      {#if lights.length === 0}
-        <p class="hint">No lights available.</p>
-      {:else}
-        <div class="light-list">
-          {#each lights as light (light.id)}
-            <label class="light-option">
-              <input type="checkbox" bind:group={selectedLightIds} value={light.id} />
-              {light.name}
-            </label>
-          {/each}
-        </div>
-      {/if}
-    </fieldset>
-
-    <label class="field">
-      <span>Zone</span>
-      <select bind:value={selectedZoneId}>
-        <option value="">No zone</option>
-        {#each zones as zone (zone.id)}
-          <option value={zone.id}>{zone.name}</option>
-        {/each}
-      </select>
-    </label>
-
-    {#if selectedZoneId}
+    {#if fixedZone}
       <p class="hint">
-        This scene will capture every light currently in this zone — the light selection above
-        is ignored once a zone is set.
+        This scene will capture every light currently in <strong>{fixedZone.name}</strong>.
       </p>
+    {:else}
+      <fieldset class="field">
+        <legend>Lights</legend>
+        {#if lights.length === 0}
+          <p class="hint">No lights available.</p>
+        {:else}
+          <div class="light-list">
+            {#each lights as light (light.id)}
+              <label class="light-option">
+                <input type="checkbox" bind:group={selectedLightIds} value={light.id} />
+                {light.name}
+              </label>
+            {/each}
+          </div>
+        {/if}
+      </fieldset>
+
+      <label class="field">
+        <span>Zone</span>
+        <select bind:value={selectedZoneId}>
+          <option value="">No zone</option>
+          {#each zones as zone (zone.id)}
+            <option value={zone.id}>{zone.name}</option>
+          {/each}
+        </select>
+      </label>
+
+      {#if selectedZoneId}
+        <p class="hint">
+          This scene will capture every light currently in this zone — the light selection above
+          is ignored once a zone is set.
+        </p>
+      {/if}
     {/if}
 
     {#if error}


### PR DESCRIPTION
## Summary
- Replaces the single global "+ New Scene" button with one at the bottom-right of each zone card, so it always creates a scene for that specific zone (as requested — the zone selector and light checklist are hidden once the zone is fixed).
- Zones with no scenes yet now still render (previously hidden entirely) so they have a button to create their first scene.
- The "Other" group (standalone/non-zone scenes) keeps no create button — that capability is intentionally dropped per the issue.
- Fixes a 422 the new flow would otherwise always hit: `SceneCreateRequest` required a non-empty `light_ids`, but the per-zone form never collects one (irrelevant for a GroupScene, whose membership comes from `group_id`). Relaxed the backend validation to only require `light_ids` when no `group_id` is given, with a new test covering it.

Fixes #30

## Test plan
- [x] `pytest` in `backend/` — 43 passed
- [x] `vite build` in `frontend/` — succeeds, no new warnings
- [x] Manually verified in browser against the real bridge: clicked a zone's "New Scene" button, created a test scene, confirmed no 422 and it appeared under that zone; deleted the test scene afterward
- [x] `/code-review` run against the diff; both findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)