### PR TITLE
Add Docker Compose + deploy script for MINIPC

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException, Request
@@ -26,7 +27,10 @@ app = FastAPI(title="Hue Light Control API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    # Defaults to the Vite dev server's origin; the prod deploy overrides
+    # this via docker-compose.yml since nginx proxies the frontend and API
+    # same-origin there.
+    allow_origins=[os.environ.get("CORS_ORIGIN", "http://localhost:5173")],
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,12 @@ services:
     # MINIPC and lets nginx (also on host networking) reach this service
     # over 127.0.0.1 without publishing/mapping a port.
     network_mode: host
+    # CORS_ORIGIN is supplied by a .env file placed by hand on the deploy
+    # target (same treatment as backend/config.yaml — never synced by
+    # deploy.sh, never committed, since it contains the real LAN address).
+    # Falls back to the Vite dev origin so `docker compose up` still works
+    # locally without one.
     environment:
-      CORS_ORIGIN: "http://192.168.x.x:8100"
+      CORS_ORIGIN: "${CORS_ORIGIN:-http://localhost:5173}"
     volumes:
       - ./backend/config.yaml:/app/config.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  backend:
+    build: ./backend
+    restart: unless-stopped
+    # Host networking matches the existing webapps/plex containers on
+    # MINIPC and lets nginx (also on host networking) reach this service
+    # over 127.0.0.1 without publishing/mapping a port.
+    network_mode: host
+    environment:
+      CORS_ORIGIN: "http://192.168.x.x:8100"
+    volumes:
+      - ./backend/config.yaml:/app/config.yaml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Manual deploy to MINIPC. Run by hand from a local checkout when you're
+# ready to ship main to production — this is not wired to CI.
+#
+# Requires:
+#   - MINIPC_HOST set to the deploy target, e.g.:
+#       export MINIPC_HOST=palmer@192.168.x.x
+#   - REMOTE_DIR set to the backend source directory on MINIPC, e.g.:
+#       export REMOTE_DIR=/opt/hue-light-control
+#   - REMOTE_STATIC_DIR set to the nginx-served static directory, e.g.:
+#       export REMOTE_STATIC_DIR=/opt/webapps/hueLightControl
+#   - One-time manual setup already done on MINIPC: those directories
+#     created, backend/config.yaml placed at $REMOTE_DIR/backend/config.yaml
+#     (scp'd by hand — never by this script), and nginx.conf wired up.
+#     See docs/deploy.md.
+set -euo pipefail
+
+: "${MINIPC_HOST:?set MINIPC_HOST, e.g. palmer@192.168.x.x}"
+: "${REMOTE_DIR:?set REMOTE_DIR, e.g. /opt/hue-light-control}"
+: "${REMOTE_STATIC_DIR:?set REMOTE_STATIC_DIR, e.g. /opt/webapps/hueLightControl}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "==> Building frontend"
+( cd "$repo_root/frontend" && npm run build )
+
+echo "==> Syncing frontend build to $MINIPC_HOST:$REMOTE_STATIC_DIR"
+rsync -az --delete "$repo_root/frontend/dist/" "$MINIPC_HOST:$REMOTE_STATIC_DIR/"
+
+echo "==> Syncing backend source to $MINIPC_HOST:$REMOTE_DIR"
+rsync -az --delete \
+  --exclude 'config.yaml' \
+  --exclude '__pycache__/' \
+  --exclude '.venv/' \
+  "$repo_root/backend/" "$MINIPC_HOST:$REMOTE_DIR/backend/"
+rsync -az "$repo_root/docker-compose.yml" "$MINIPC_HOST:$REMOTE_DIR/docker-compose.yml"
+
+echo "==> Rebuilding and restarting backend container"
+ssh "$MINIPC_HOST" "cd $REMOTE_DIR && docker compose up -d --build"
+
+echo "==> Done. If nginx.conf changed, restart the webapps container by hand."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,9 +10,11 @@
 #   - REMOTE_STATIC_DIR set to the nginx-served static directory, e.g.:
 #       export REMOTE_STATIC_DIR=/opt/webapps/hueLightControl
 #   - One-time manual setup already done on MINIPC: those directories
-#     created, backend/config.yaml placed at $REMOTE_DIR/backend/config.yaml
-#     (scp'd by hand — never by this script), and nginx.conf wired up.
-#     See docs/deploy.md.
+#     created, backend/config.yaml placed at $REMOTE_DIR/backend/config.yaml,
+#     a .env placed at $REMOTE_DIR/.env with the real CORS_ORIGIN (both
+#     scp'd by hand — never by this script, which only ever syncs
+#     docker-compose.yml itself, not the directory it lives in), and
+#     nginx.conf wired up. See docs/deploy.md.
 set -euo pipefail
 
 : "${MINIPC_HOST:?set MINIPC_HOST, e.g. palmer@192.168.x.x}"


### PR DESCRIPTION
## Summary
- Backend `docker-compose.yml`: host networking (matches existing `webapps`/`plex` containers on MINIPC), bind-mounts `backend/config.yaml`, `restart: unless-stopped`.
- CORS origin in `backend/app/main.py` is now configurable via `CORS_ORIGIN` env var (defaults to the Vite dev origin), overridden in `docker-compose.yml` for prod since nginx will reverse-proxy same-origin.
- `scripts/deploy.sh`: manual deploy script — builds the frontend locally (no Node on MINIPC), rsyncs the build + backend source, then runs `docker compose up -d --build` on MINIPC. Excludes `config.yaml` from sync (deployed by hand, one time).
- `docs/deploy.md` (local-only, gitignored): MINIPC layout, one-time nginx/bind-mount setup, how to run the deploy script, rollback notes.

Closes #1.

## Test plan
- [x] `pytest` in `backend/` — 43 passed
- [x] `docker-compose.yml` validated as YAML
- [x] `scripts/deploy.sh` passed `bash -n` syntax check
- [ ] End-to-end deploy against real MINIPC (one-time manual setup + first `deploy.sh` run) — tracked as a follow-up once this PR merges, since it requires hand-placing `backend/config.yaml` and editing MINIPC's nginx.conf outside of git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)