### PR TITLE
Replace per-scene brightness sliders with a per-zone slider

### DIFF
--- a/backend/HUE_API.md
+++ b/backend/HUE_API.md
@@ -112,34 +112,34 @@ whatever they're currently at.
 
 Confirms what the Groups section above already documents: there's no
 scene-specific "activate" endpoint. The app's `POST
-/api/scenes/<id>/activate` route (body: `{"group_id": "<id>", "brightness_pct":
-<1-100, optional>}`) turns around and issues `PUT
-/api/<username>/groups/<group_id>/action` with `{"scene": "<id>"}` — the
-same call the Groups/Scenes sections describe. `group_id` must be supplied
-by the caller (the frontend gets it from the scene's own `group_id`, which
-is null for a standalone `LightScene` — those can't be activated this way
-and the frontend disables them).
+/api/scenes/<id>/activate` route (body: `{"group_id": "<id>"}`) turns
+around and issues `PUT /api/<username>/groups/<group_id>/action` with
+`{"scene": "<id>"}` — the same call the Groups/Scenes sections describe.
+`group_id` must be supplied by the caller (the frontend gets it from the
+scene's own `group_id`, which is null for a standalone `LightScene` —
+those can't be activated this way and the frontend disables them).
 
 Since activation is a PUT (idempotent — resending "activate this scene"
 twice is harmless), it goes through the normal rediscovery-retry path,
 unlike scene creation's POST.
 
-`brightness_pct`, when given, requires a **second** sequential PUT — confirmed
-against a real bridge. Sending `{"scene": "<id>", "bri": <N>}` in a single
-call reports `"success"` for both fields, but the scene recall wins: every
-light in the group ends up at whatever brightness the scene itself stored,
-silently ignoring the requested `bri`. Getting the requested brightness to
-actually apply requires two sequential PUTs to the same
-`groups/<group_id>/action` endpoint:
+Confirmed against a real bridge: sending `{"scene": "<id>", "bri": <N>}`
+in a single call reports `"success"` for both fields, but the scene
+recall wins — every light in the group ends up at whatever brightness the
+scene itself stored, silently ignoring the requested `bri`. So scene
+activation never attempts to set a brightness at all.
 
-1. `{"scene": "<id>"}` — recall the scene.
-2. `{"bri": <N>}` — scale whatever's now on in the group to the requested
-   brightness.
+### Setting zone brightness (issue #47)
 
-This powers the frontend's per-scene brightness slider: moving the slider
-and releasing it re-activates the scene at that brightness in one user
-action (no live-adjustment of an already-active scene, and no brightness
-state tracked for a scene between activations).
+Scenes in a given zone all recall the same bulbs, so there's no such
+thing as a scene-specific brightness — the app doesn't try to offer one.
+Instead `PUT /api/zones/<id>/state` (body: `{"brightness_pct": <1-100>}`)
+issues a single standalone `PUT /api/<username>/groups/<group_id>/action`
+with `{"bri": <N>}` — no `scene` field, so there's no recall to compete
+with it and no need for the two-PUT dance a combined `{"scene", "bri"}`
+call would require (see above). This is what powers the frontend's
+per-zone brightness slider, shown once per zone rather than once per
+scene.
 
 ## Full CLIP v1 resource catalog (research: issue #29)
 

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -47,6 +47,7 @@ class Zone(BaseModel):
     id: str
     name: str
     light_count: int
+    light_ids: list[str] = []
 
 
 def _to_hex(r: float, g: float, b: float) -> str:
@@ -283,10 +284,12 @@ async def get_scenes(config: BridgeConfig) -> list[Scene]:
 
 
 def _to_zone(group_id: str, raw: dict) -> Zone:
+    light_ids = raw.get("lights", [])
     return Zone(
         id=group_id,
         name=raw.get("name", f"Zone {group_id}"),
-        light_count=len(raw.get("lights", [])),
+        light_count=len(light_ids),
+        light_ids=light_ids,
     )
 
 
@@ -337,9 +340,7 @@ async def set_light_state(
     await _bridge_request(config, f"lights/{light_id}/state", method="PUT", json_body=body)
 
 
-async def activate_scene(
-    config: BridgeConfig, group_id: str, scene_id: str, brightness_pct: Optional[int] = None
-) -> None:
+async def activate_scene(config: BridgeConfig, group_id: str, scene_id: str) -> None:
     """Activate a scene via its owning group's action endpoint.
 
     Hue has no dedicated "activate scene" endpoint — scenes are applied by
@@ -347,23 +348,24 @@ async def activate_scene(
     HUE_API.md's Scenes section). This is a PUT, so unlike create_scene's
     POST it's safe to let it go through the normal rediscovery-retry path:
     resending "activate this scene" twice is harmless.
-
-    Confirmed against a real bridge: combining {"scene": id, "bri": N} in a
-    single PUT does NOT scale the scene to N — the bridge reports "success"
-    for both fields, but the scene recall wins and each light ends up at
-    whatever brightness the scene itself stored, ignoring the requested
-    `bri`. Getting the requested brightness to actually apply requires two
-    sequential PUTs: first recall the scene, then a second PUT to scale
-    whatever's now on in the group to the requested `bri`.
     """
     await _bridge_request(config, f"groups/{group_id}/action", method="PUT", json_body={"scene": scene_id})
-    if brightness_pct is not None:
-        await _bridge_request(
-            config,
-            f"groups/{group_id}/action",
-            method="PUT",
-            json_body={"bri": _pct_to_bri(brightness_pct)},
-        )
+
+
+async def set_group_brightness(config: BridgeConfig, group_id: str, brightness_pct: int) -> None:
+    """Set brightness for every light in a group/zone at once, independent of any scene.
+
+    Scenes in the same zone/group share the same bulbs, so there's no such
+    thing as a scene-specific brightness — this is the single source of
+    truth for a zone's brightness (see issue #47). Confirmed against a real
+    bridge (see HUE_API.md's "Activating a scene" section): combining
+    {"scene": id, "bri": N} in one PUT lets the scene recall win and ignores
+    `bri`, but a standalone {"bri": N} PUT to the group's action endpoint —
+    with no scene involved — scales every light in the group as expected.
+    """
+    await _bridge_request(
+        config, f"groups/{group_id}/action", method="PUT", json_body={"bri": _pct_to_bri(brightness_pct)}
+    )
 
 
 async def get_group_light_ids(config: BridgeConfig, group_id: str) -> list[str]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from app.hue_client import (
     get_lights,
     get_scenes,
     get_zones,
+    set_group_brightness,
     set_light_state,
 )
 
@@ -137,15 +138,21 @@ async def create_scene_route(body: SceneCreateRequest) -> Scene:
 
 class SceneActivateRequest(BaseModel):
     group_id: str
-    # Wired up in the frontend as the per-scene brightness slider (scale-
-    # on-activate: moving the slider re-activates the scene at that
-    # brightness). See activate_scene's docstring for the confirmed
-    # two-PUT behavior this relies on.
-    brightness_pct: Optional[int] = Field(default=None, ge=1, le=100)
 
 
 @app.post("/api/scenes/{scene_id}/activate")
 async def activate_scene_route(scene_id: str, body: SceneActivateRequest):
     config = load_config()
-    await activate_scene(config, body.group_id, scene_id, brightness_pct=body.brightness_pct)
+    await activate_scene(config, body.group_id, scene_id)
+    return {"status": "ok"}
+
+
+class ZoneStateUpdate(BaseModel):
+    brightness_pct: int = Field(..., ge=1, le=100)
+
+
+@app.put("/api/zones/{zone_id}/state")
+async def update_zone_state(zone_id: str, update: ZoneStateUpdate):
+    config = load_config()
+    await set_group_brightness(config, zone_id, update.brightness_pct)
     return {"status": "ok"}

--- a/backend/tests/test_existing_routes.py
+++ b/backend/tests/test_existing_routes.py
@@ -75,7 +75,7 @@ async def test_list_zones(client):
 
     assert resp.status_code == 200
     assert resp.json() == [
-        {"id": "3", "name": "Living Room", "light_count": 2},
+        {"id": "3", "name": "Living Room", "light_count": 2, "light_ids": ["1", "2"]},
     ]
 
 

--- a/backend/tests/test_scene_routes.py
+++ b/backend/tests/test_scene_routes.py
@@ -26,48 +26,6 @@ async def test_activate_scene_missing_group_id_is_422(client):
 
 
 @respx.mock
-async def test_activate_scene_with_brightness_sends_two_sequential_puts(client):
-    action_route = respx.put(f"{BRIDGE_URL}/groups/g1/action").mock(
-        side_effect=[
-            Response(200, json=[{"success": {"/groups/g1/action/scene": "abc123"}}]),
-            Response(200, json=[{"success": {"/groups/g1/action/bri": 127}}]),
-        ]
-    )
-
-    resp = await client.post(
-        "/api/scenes/abc123/activate", json={"group_id": "g1", "brightness_pct": 50}
-    )
-
-    assert resp.status_code == 200
-    # Confirmed against a real bridge (see HUE_API.md's "Activating a
-    # scene" section): a single PUT combining scene+bri lets the scene's
-    # own stored brightness win, silently ignoring the requested bri. Two
-    # sequential PUTs — recall, then scale — are required instead.
-    assert action_route.call_count == 2
-    assert json.loads(action_route.calls[0].request.content) == {"scene": "abc123"}
-    assert json.loads(action_route.calls[1].request.content) == {"bri": 127}
-
-
-@respx.mock
-async def test_activate_scene_with_brightness_second_put_error_returns_502(client):
-    # The scene recall (first PUT) succeeds but the brightness scale
-    # (second PUT) is rejected — the whole request should still surface as
-    # an error, not a silent partial success.
-    respx.put(f"{BRIDGE_URL}/groups/g1/action").mock(
-        side_effect=[
-            Response(200, json=[{"success": {"/groups/g1/action/scene": "abc123"}}]),
-            Response(200, json=[{"error": {"description": "invalid/missing parameters in body"}}]),
-        ]
-    )
-
-    resp = await client.post(
-        "/api/scenes/abc123/activate", json={"group_id": "g1", "brightness_pct": 50}
-    )
-
-    assert resp.status_code == 502
-
-
-@respx.mock
 async def test_activate_scene_bridge_error_returns_502(client):
     respx.put(f"{BRIDGE_URL}/groups/g1/action").mock(
         return_value=Response(200, json=[{"error": {"description": "invalid/missing parameters in body"}}])

--- a/backend/tests/test_zone_routes.py
+++ b/backend/tests/test_zone_routes.py
@@ -1,0 +1,52 @@
+import json
+
+import respx
+from httpx import Response
+
+BRIDGE_URL = "http://192.168.x.x/api/test-api-key"
+
+
+@respx.mock
+async def test_update_zone_state(client):
+    action_route = respx.put(f"{BRIDGE_URL}/groups/z1/action").mock(
+        return_value=Response(200, json=[{"success": {"/groups/z1/action/bri": 127}}])
+    )
+
+    resp = await client.put("/api/zones/z1/state", json={"brightness_pct": 50})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    assert json.loads(action_route.calls.last.request.content) == {"bri": 127}
+
+
+async def test_update_zone_state_missing_brightness_pct_is_422(client):
+    resp = await client.put("/api/zones/z1/state", json={})
+
+    assert resp.status_code == 422
+
+
+async def test_update_zone_state_out_of_range_brightness_pct_is_422(client):
+    resp = await client.put("/api/zones/z1/state", json={"brightness_pct": 0})
+
+    assert resp.status_code == 422
+
+
+@respx.mock
+async def test_update_zone_state_bridge_error_returns_502(client):
+    respx.put(f"{BRIDGE_URL}/groups/z1/action").mock(
+        return_value=Response(200, json=[{"error": {"description": "invalid/missing parameters in body"}}])
+    )
+
+    resp = await client.put("/api/zones/z1/state", json={"brightness_pct": 50})
+
+    assert resp.status_code == 502
+
+
+async def test_update_zone_state_bridge_not_configured_returns_503(client, monkeypatch):
+    from app.config import BridgeConfig
+
+    monkeypatch.setattr("app.main.load_config", lambda: BridgeConfig())
+
+    resp = await client.put("/api/zones/z1/state", json={"brightness_pct": 50})
+
+    assert resp.status_code == 503

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte'
   import LightCard from './LightCard.svelte'
   import SceneCard from './SceneCard.svelte'
+  import ZoneBrightnessSlider from './ZoneBrightnessSlider.svelte'
   import CreateSceneForm from './CreateSceneForm.svelte'
   import { fetchJson, postJson, putJson } from './api.js'
 
@@ -101,7 +102,10 @@
   // dropped when empty.
   let zoneGroups = $derived.by(() => {
     const byId = new Map(
-      zones.map((zone) => [zone.id, { id: zone.id, name: zone.name, scenes: [], isZone: true }])
+      zones.map((zone) => [
+        zone.id,
+        { id: zone.id, name: zone.name, lightIds: zone.light_ids, scenes: [], isZone: true },
+      ])
     )
     const other = { id: 'other', name: 'Other', scenes: [], isZone: false }
     for (const scene of scenes) {
@@ -177,24 +181,25 @@
   // set and revert for a one-shot action like activating a scene — just
   // surface a per-card error on failure. SceneCard guards against overlapping
   // double-click requests itself (same pattern as LightCard's toggle button).
-  //
-  // brightnessPct is optional: plain click-to-activate (issue #11) omits it,
-  // the per-scene brightness slider (issue #14) passes it. There's no
-  // "currently active scene brightness" tracked anywhere — moving the
-  // slider just re-activates the scene at that brightness (see
-  // HUE_API.md's "Activating a scene" section).
-  async function activateScene(sceneId, groupId, brightnessPct) {
+  async function activateScene(sceneId, groupId) {
     const scene = scenes.find((s) => s.id === sceneId)
     if (!scene) return
     scene.activateError = null
     try {
-      const body =
-        brightnessPct == null ? { group_id: groupId } : { group_id: groupId, brightness_pct: brightnessPct }
-      await postJson(`/api/scenes/${sceneId}/activate`, body)
+      await postJson(`/api/scenes/${sceneId}/activate`, { group_id: groupId })
       await refreshLights()
     } catch (err) {
       scene.activateError = err.message
     }
+  }
+
+  // Scenes in the same zone share the same bulbs, so there's no such thing
+  // as a scene-specific brightness (issue #47) — this sets the zone's
+  // brightness directly, independent of any scene. Errors are surfaced by
+  // ZoneBrightnessSlider itself (it awaits this call), not stashed here.
+  async function setZoneBrightness(zoneId, pct) {
+    await putJson(`/api/zones/${zoneId}/state`, { brightness_pct: pct })
+    await refreshLights()
   }
 </script>
 
@@ -251,13 +256,18 @@
         {/if}
         {#each zoneGroups as group (group.id)}
           <div class="zone-group">
-            <h3>{group.name}</h3>
+            <div class="zone-header">
+              <h3>{group.name}</h3>
+              {#if group.isZone}
+                <ZoneBrightnessSlider zone={group} {lights} onSetBrightness={setZoneBrightness} />
+              {/if}
+            </div>
             {#if group.scenes.length === 0}
               <p class="hint">No scenes in this zone yet.</p>
             {:else}
               <div class="grid">
                 {#each group.scenes as scene (scene.id)}
-                  <SceneCard {scene} {lights} onActivate={activateScene} />
+                  <SceneCard {scene} onActivate={activateScene} />
                 {/each}
               </div>
             {/if}
@@ -371,11 +381,19 @@
     margin-top: 1.5rem;
   }
 
-  .zone-group h3 {
-    margin: 0 0 0.75rem;
+  .zone-header {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .zone-header h3 {
+    margin: 0;
     font-size: 0.95rem;
     font-weight: 600;
     color: light-dark(#555, #aaa);
+    flex-shrink: 0;
   }
 
   .zone-group-footer {

--- a/frontend/src/SceneCard.svelte
+++ b/frontend/src/SceneCard.svelte
@@ -1,50 +1,21 @@
 <script>
-  import BrightnessSlider from './BrightnessSlider.svelte'
-
-  let { scene, lights, onActivate } = $props()
+  let { scene, onActivate } = $props()
 
   // Standalone LightScenes (no group_id) can't be activated via the
   // group-action endpoint (see HUE_API.md's Scenes section) — render them
   // as non-interactive instead of wiring up a click handler.
   let activatable = $derived(scene.group_id != null)
 
-  // The bridge has no concept of "is this scene active" or "what's this
-  // scene's current brightness" (confirmed directly against a real bridge —
-  // group.action never records which scene, if any, was last recalled, and
-  // a scene's own stored lightstates reflect creation time, not now). So
-  // rather than asking the bridge, derive both from the same live
-  // /api/lights data the Bulbs section already shows, matched against this
-  // scene's light_ids — that's always accurate and free (no extra
-  // request), and updates automatically whenever `lights` does (a bulb
-  // toggle, or App's refreshLights() after any scene activation).
-  let sceneLights = $derived(lights.filter((light) => scene.light_ids.includes(light.id)))
-  let onLights = $derived(sceneLights.filter((light) => light.on))
-
-  // Only "off" once lights have actually loaded (sceneLights is briefly
-  // empty before that, at which point this stays false, leaving the slider
-  // enabled and at the fallback below rather than flashing "off").
-  let off = $derived(sceneLights.length > 0 && onLights.length === 0)
-
-  // Average brightness across just the on lights, clamped to 1 (the bridge
-  // and BrightnessSlider's min never accept 0). Falls back to 100 while
-  // lights haven't loaded yet, or if the scene isn't on.
-  let liveBrightnessPct = $derived(
-    onLights.length > 0
-      ? Math.max(Math.round(onLights.reduce((sum, light) => sum + light.brightness_pct, 0) / onLights.length), 1)
-      : 100
-  )
-
-  // Serializes both activation paths (plain click and the brightness
-  // slider) for this card: while a request is in flight both controls are
-  // disabled, so a fast click-then-drag (or vice versa) can't fire a
+  // Serializes activation clicks for this card: while a request is in
+  // flight the button is disabled, so a fast double-click can't fire a
   // second overlapping activate request.
   let pending = $state(false)
 
-  async function activate(brightnessPct) {
+  async function activate() {
     if (pending || !activatable) return
     pending = true
     try {
-      await onActivate(scene.id, scene.group_id, brightnessPct)
+      await onActivate(scene.id, scene.group_id)
     } finally {
       pending = false
     }
@@ -64,14 +35,6 @@
       <span class="badge error-badge">{scene.activateError}</span>
     {/if}
   </button>
-
-  <BrightnessSlider
-    value={liveBrightnessPct}
-    label="{scene.name} brightness"
-    disabled={!activatable || pending || off}
-    showValue={!off}
-    onChange={activate}
-  />
 </div>
 
 <style>

--- a/frontend/src/ZoneBrightnessSlider.svelte
+++ b/frontend/src/ZoneBrightnessSlider.svelte
@@ -1,0 +1,79 @@
+<script>
+  import BrightnessSlider from './BrightnessSlider.svelte'
+
+  let { zone, lights, onSetBrightness } = $props()
+
+  // Same derivation SceneCard used to do per-scene (issue #47's whole
+  // point: scenes in the same zone share bulbs, so this is the one true
+  // brightness for the zone) — matched against the zone's own light_ids
+  // rather than any particular scene's, so it stays accurate even when the
+  // zone has no scenes yet.
+  let zoneLights = $derived(lights.filter((light) => zone.lightIds.includes(light.id)))
+  let onLights = $derived(zoneLights.filter((light) => light.on))
+
+  // Only "off" once lights have actually loaded (zoneLights is briefly
+  // empty before that, at which point this stays false, leaving the slider
+  // enabled and at the fallback below rather than flashing "off").
+  let off = $derived(zoneLights.length > 0 && onLights.length === 0)
+
+  // Average brightness across just the on lights, clamped to 1 (the bridge
+  // and BrightnessSlider's min never accept 0). Falls back to 100 while
+  // lights haven't loaded yet, or if the zone isn't on.
+  let liveBrightnessPct = $derived(
+    onLights.length > 0
+      ? Math.max(Math.round(onLights.reduce((sum, light) => sum + light.brightness_pct, 0) / onLights.length), 1)
+      : 100
+  )
+
+  let pending = $state(false)
+  let error = $state(null)
+
+  async function setBrightness(pct) {
+    if (pending) return
+    pending = true
+    error = null
+    try {
+      await onSetBrightness(zone.id, pct)
+    } catch (err) {
+      error = err.message
+    } finally {
+      pending = false
+    }
+  }
+</script>
+
+<div class="zone-brightness">
+  <BrightnessSlider
+    value={liveBrightnessPct}
+    label="{zone.name} brightness"
+    disabled={pending || off || zoneLights.length === 0}
+    showValue={!off}
+    onChange={setBrightness}
+  />
+  {#if error}
+    <span class="badge error-badge">{error}</span>
+  {/if}
+</div>
+
+<style>
+  .zone-brightness {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 1 1 12rem;
+    min-width: 8rem;
+  }
+
+  .badge {
+    font-size: 0.75rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    width: fit-content;
+    flex-shrink: 0;
+  }
+
+  .error-badge {
+    background: light-dark(#fbe3e0, #3d211f);
+    color: light-dark(#a3392c, #f0958a);
+  }
+</style>


### PR DESCRIPTION
## Summary
- Scenes in the same zone share the same bulbs, so a scene's brightness slider always moved every other scene in that zone to the same value (the scene-activate flow's second PUT scales the whole group, not just that scene). Removed the redundant per-scene sliders.
- Added a single per-zone brightness slider (`ZoneBrightnessSlider.svelte`), rendered in each zone's header, that sets the zone's brightness directly via a new `PUT /api/zones/{zone_id}/state` route — independent of any scene.
- Backend: `Zone` now carries `light_ids` (mirrors `Scene`); `set_group_brightness` is a new standalone helper extracted from `activate_scene`'s old second PUT; `activate_scene`/`SceneActivateRequest` dropped the now-unused `brightness_pct` param.

Closes #47.

## Test plan
- [x] `pytest` in `backend/` — 46 passed (2 obsolete tests removed, 5 new zone-route tests added, `test_list_zones` updated for `light_ids`)
- [x] `npm run build` in `frontend/` — succeeds
- [x] Manually exercised in a browser against the real bridge (`make dev`-equivalent): scene cards show no slider and still activate correctly; each zone header shows one brightness slider; dragging it changes brightness for that zone's bulbs and the slider reflects the reconciled value afterward; a second, independent zone was unaffected by the first zone's slider
- [x] No browser console errors during manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)