### PR TITLE
Add per-zone Off button, let brightness slider reach 0

### DIFF
--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -352,8 +352,10 @@ async def activate_scene(config: BridgeConfig, group_id: str, scene_id: str) -> 
     await _bridge_request(config, f"groups/{group_id}/action", method="PUT", json_body={"scene": scene_id})
 
 
-async def set_group_brightness(config: BridgeConfig, group_id: str, brightness_pct: int) -> None:
-    """Set brightness for every light in a group/zone at once, independent of any scene.
+async def set_group_state(
+    config: BridgeConfig, group_id: str, *, on: Optional[bool] = None, brightness_pct: Optional[int] = None
+) -> None:
+    """Set on/off and/or brightness for every light in a group/zone at once, independent of any scene.
 
     Scenes in the same zone/group share the same bulbs, so there's no such
     thing as a scene-specific brightness — this is the single source of
@@ -362,10 +364,14 @@ async def set_group_brightness(config: BridgeConfig, group_id: str, brightness_p
     {"scene": id, "bri": N} in one PUT lets the scene recall win and ignores
     `bri`, but a standalone {"bri": N} PUT to the group's action endpoint —
     with no scene involved — scales every light in the group as expected.
+    Unlike `scene`, `on` and `bri` combine fine in a single PUT.
     """
-    await _bridge_request(
-        config, f"groups/{group_id}/action", method="PUT", json_body={"bri": _pct_to_bri(brightness_pct)}
-    )
+    body = {}
+    if on is not None:
+        body["on"] = on
+    if brightness_pct is not None:
+        body["bri"] = _pct_to_bri(brightness_pct)
+    await _bridge_request(config, f"groups/{group_id}/action", method="PUT", json_body=body)
 
 
 async def get_group_light_ids(config: BridgeConfig, group_id: str) -> list[str]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,7 @@ from app.hue_client import (
     get_lights,
     get_scenes,
     get_zones,
-    set_group_brightness,
+    set_group_state,
     set_light_state,
 )
 
@@ -148,11 +148,16 @@ async def activate_scene_route(scene_id: str, body: SceneActivateRequest):
 
 
 class ZoneStateUpdate(BaseModel):
-    brightness_pct: int = Field(..., ge=1, le=100)
+    on: Optional[bool] = None
+    # 0 isn't a settable target (that's what on: false is for) — matches
+    # _pct_to_bri's floor of 1.
+    brightness_pct: Optional[int] = Field(default=None, ge=1, le=100)
 
 
 @app.put("/api/zones/{zone_id}/state")
 async def update_zone_state(zone_id: str, update: ZoneStateUpdate):
+    if update.on is None and update.brightness_pct is None:
+        raise HTTPException(status_code=400, detail="must set on and/or brightness_pct")
     config = load_config()
-    await set_group_brightness(config, zone_id, update.brightness_pct)
+    await set_group_state(config, zone_id, on=update.on, brightness_pct=update.brightness_pct)
     return {"status": "ok"}

--- a/backend/tests/test_zone_routes.py
+++ b/backend/tests/test_zone_routes.py
@@ -19,10 +19,34 @@ async def test_update_zone_state(client):
     assert json.loads(action_route.calls.last.request.content) == {"bri": 127}
 
 
-async def test_update_zone_state_missing_brightness_pct_is_422(client):
+async def test_update_zone_state_neither_field_is_400(client):
     resp = await client.put("/api/zones/z1/state", json={})
 
-    assert resp.status_code == 422
+    assert resp.status_code == 400
+
+
+@respx.mock
+async def test_update_zone_state_off(client):
+    action_route = respx.put(f"{BRIDGE_URL}/groups/z1/action").mock(
+        return_value=Response(200, json=[{"success": {"/groups/z1/action/on": False}}])
+    )
+
+    resp = await client.put("/api/zones/z1/state", json={"on": False})
+
+    assert resp.status_code == 200
+    assert json.loads(action_route.calls.last.request.content) == {"on": False}
+
+
+@respx.mock
+async def test_update_zone_state_on_and_brightness_pct_combine(client):
+    action_route = respx.put(f"{BRIDGE_URL}/groups/z1/action").mock(
+        return_value=Response(200, json=[{"success": {"/groups/z1/action/bri": 127}}])
+    )
+
+    resp = await client.put("/api/zones/z1/state", json={"on": True, "brightness_pct": 50})
+
+    assert resp.status_code == 200
+    assert json.loads(action_route.calls.last.request.content) == {"on": True, "bri": 127}
 
 
 async def test_update_zone_state_out_of_range_brightness_pct_is_422(client):

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -197,8 +197,16 @@
   // as a scene-specific brightness (issue #47) — this sets the zone's
   // brightness directly, independent of any scene. Errors are surfaced by
   // ZoneBrightnessSlider itself (it awaits this call), not stashed here.
+  // Dragging brightness up implies the zone is on, same as setLightBrightness
+  // does per-light — otherwise a light the Off button (or an earlier 0 drag)
+  // turned off would take the new bri without actually turning back on.
   async function setZoneBrightness(zoneId, pct) {
-    await putJson(`/api/zones/${zoneId}/state`, { brightness_pct: pct })
+    await putJson(`/api/zones/${zoneId}/state`, { brightness_pct: pct, on: true })
+    await refreshLights()
+  }
+
+  async function setZoneOn(zoneId, on) {
+    await putJson(`/api/zones/${zoneId}/state`, { on })
     await refreshLights()
   }
 </script>
@@ -259,7 +267,7 @@
             <div class="zone-header">
               <h3>{group.name}</h3>
               {#if group.isZone}
-                <ZoneBrightnessSlider zone={group} {lights} onSetBrightness={setZoneBrightness} />
+                <ZoneBrightnessSlider zone={group} {lights} onSetBrightness={setZoneBrightness} onSetZoneOn={setZoneOn} />
               {/if}
             </div>
             {#if group.scenes.length === 0}

--- a/frontend/src/BrightnessSlider.svelte
+++ b/frontend/src/BrightnessSlider.svelte
@@ -1,6 +1,8 @@
 <script>
-  // The bridge (and backend validation) rejects brightness_pct below 1 —
-  // 0 isn't a meaningful "on" brightness, off is the separate toggle.
+  // The bridge (and backend validation) rejects brightness_pct below 1 — 0
+  // isn't a meaningful "on" brightness. Callers that want a 0 rung (e.g. the
+  // zone slider, where 0 means "turn off") pass min={0} and must translate a
+  // 0 onChange into an off command themselves rather than brightness_pct: 0.
   let { value, min = 1, max = 100, disabled = false, showValue = true, label, onChange } = $props()
   let localValue = $state(value)
   $effect(() => { localValue = value })

--- a/frontend/src/ZoneBrightnessSlider.svelte
+++ b/frontend/src/ZoneBrightnessSlider.svelte
@@ -1,7 +1,7 @@
 <script>
   import BrightnessSlider from './BrightnessSlider.svelte'
 
-  let { zone, lights, onSetBrightness } = $props()
+  let { zone, lights, onSetBrightness, onSetZoneOn } = $props()
 
   // Same derivation SceneCard used to do per-scene (issue #47's whole
   // point: scenes in the same zone share bulbs, so this is the one true
@@ -13,32 +13,45 @@
 
   // Only "off" once lights have actually loaded (zoneLights is briefly
   // empty before that, at which point this stays false, leaving the slider
-  // enabled and at the fallback below rather than flashing "off").
+  // at the fallback below rather than flashing "off").
   let off = $derived(zoneLights.length > 0 && onLights.length === 0)
 
-  // Average brightness across just the on lights, clamped to 1 (the bridge
-  // and BrightnessSlider's min never accept 0). Falls back to 100 while
-  // lights haven't loaded yet, or if the zone isn't on.
+  // Average brightness across just the on lights. 0 when the zone is off —
+  // the slider's min is 0 here (unlike BrightnessSlider's own default of 1)
+  // specifically so "off" has a slider position, and dragging back up is how
+  // the zone turns back on. Falls back to 100 while lights haven't loaded yet.
   let liveBrightnessPct = $derived(
-    onLights.length > 0
-      ? Math.max(Math.round(onLights.reduce((sum, light) => sum + light.brightness_pct, 0) / onLights.length), 1)
-      : 100
+    off
+      ? 0
+      : onLights.length > 0
+        ? Math.round(onLights.reduce((sum, light) => sum + light.brightness_pct, 0) / onLights.length)
+        : 100
   )
 
   let pending = $state(false)
   let error = $state(null)
 
-  async function setBrightness(pct) {
+  async function runUpdate(action) {
     if (pending) return
     pending = true
     error = null
     try {
-      await onSetBrightness(zone.id, pct)
+      await action()
     } catch (err) {
       error = err.message
     } finally {
       pending = false
     }
+  }
+
+  // Dragging to 0 is an off command, not brightness_pct: 0 (the bridge
+  // rejects that) — everything above 0 sets brightness and implies on.
+  function setBrightness(pct) {
+    runUpdate(() => (pct === 0 ? onSetZoneOn(zone.id, false) : onSetBrightness(zone.id, pct)))
+  }
+
+  function turnOff() {
+    runUpdate(() => onSetZoneOn(zone.id, false))
   }
 </script>
 
@@ -46,10 +59,13 @@
   <BrightnessSlider
     value={liveBrightnessPct}
     label="{zone.name} brightness"
-    disabled={pending || off || zoneLights.length === 0}
-    showValue={!off}
+    min={0}
+    disabled={pending || zoneLights.length === 0}
     onChange={setBrightness}
   />
+  <button type="button" class="zone-off-button" disabled={pending || off || zoneLights.length === 0} onclick={turnOff}>
+    Off
+  </button>
   {#if error}
     <span class="badge error-badge">{error}</span>
   {/if}
@@ -75,5 +91,26 @@
   .error-badge {
     background: light-dark(#fbe3e0, #3d211f);
     color: light-dark(#a3392c, #f0958a);
+  }
+
+  .zone-off-button {
+    font: inherit;
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    background: light-dark(#eee, #333);
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .zone-off-button:hover:not(:disabled) {
+    filter: brightness(0.95);
+  }
+
+  .zone-off-button:disabled {
+    opacity: 0.55;
+    cursor: default;
   }
 </style>


### PR DESCRIPTION
## Summary
- Zone brightness previously floored at 1%, since the Hue bridge rejects `bri: 0` — there was no way to turn a whole zone off from the slider.
- Slider min is now 0; dragging to 0 sends an off command (`{on: false}`) instead of an invalid `brightness_pct: 0`, and a new Off button gives a one-click path to the same action.
- The slider is never disabled while off — dragging it back up turns the zone back on, correctly forcing `on: true` alongside the new brightness (matching how per-light brightness already implies on).
- Backend: `ZoneStateUpdate` now accepts an optional `on` field alongside `brightness_pct`; `set_group_brightness` renamed to `set_group_state` to PUT `on`/`bri` together in one request to the group's action endpoint.

## Test plan
- [x] Backend test suite passes (48 tests), including new coverage for `on: false` and combined `on`+`brightness_pct` requests
- [x] `npm run build` succeeds with no new warnings
- [x] Manually exercised against the real bridge in the browser: zone Off button turns all zone lights off; dragging the slider up from 0 turns the zone back on at the dragged brightness; individual light cards reflect the change after refresh
- [x] `/code-review medium` — no findings