### PR TITLE
Zone brightness slider only affects bulbs currently on

### DIFF
--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -382,3 +382,19 @@ async def get_group_light_ids(config: BridgeConfig, group_id: str) -> list[str]:
     """
     data = await _bridge_request(config, f"groups/{group_id}")
     return data.get("lights", [])
+
+
+async def set_zone_brightness_for_on_lights(config: BridgeConfig, group_id: str, brightness_pct: int) -> None:
+    """Adjust brightness for only the zone's currently-on lights, leaving off ones off.
+
+    Unlike set_group_state's group-action PUT (which is what turns a whole
+    zone on/off together), a plain slider drag shouldn't wake up bulbs the
+    user deliberately turned off individually — so this fetches current
+    on/off state first and only targets lights that are already on.
+    """
+    light_ids, lights = await asyncio.gather(get_group_light_ids(config, group_id), get_lights(config))
+    on_ids = {light.id for light in lights if light.on}
+    target_ids = [light_id for light_id in light_ids if light_id in on_ids]
+    await asyncio.gather(
+        *(set_light_state(config, light_id, brightness_pct=brightness_pct) for light_id in target_ids)
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.hue_client import (
     get_zones,
     set_group_state,
     set_light_state,
+    set_zone_brightness_for_on_lights,
 )
 
 app = FastAPI(title="Hue Light Control API")
@@ -159,5 +160,13 @@ async def update_zone_state(zone_id: str, update: ZoneStateUpdate):
     if update.on is None and update.brightness_pct is None:
         raise HTTPException(status_code=400, detail="must set on and/or brightness_pct")
     config = load_config()
-    await set_group_state(config, zone_id, on=update.on, brightness_pct=update.brightness_pct)
+    if update.on is not None:
+        # Explicit on/off (the zone Off button, or the frontend's "drag up
+        # from fully off" gesture) — applies to every light in the zone via
+        # one group-action PUT, same as before.
+        await set_group_state(config, zone_id, on=update.on, brightness_pct=update.brightness_pct)
+    else:
+        # A plain brightness drag on an already-partially-on zone shouldn't
+        # wake up bulbs the user individually turned off.
+        await set_zone_brightness_for_on_lights(config, zone_id, update.brightness_pct)
     return {"status": "ok"}

--- a/backend/tests/test_zone_routes.py
+++ b/backend/tests/test_zone_routes.py
@@ -6,17 +6,48 @@ from httpx import Response
 BRIDGE_URL = "http://192.168.x.x/api/test-api-key"
 
 
+def _mock_zone_lights(*, group_lights, light_states):
+    """Mock GET /groups/z1 (membership) and GET /lights (on/off + bri) together —
+    set_zone_brightness_for_on_lights fetches both before targeting on lights."""
+    respx.get(f"{BRIDGE_URL}/groups/z1").mock(return_value=Response(200, json={"lights": group_lights}))
+    respx.get(f"{BRIDGE_URL}/lights").mock(
+        return_value=Response(
+            200,
+            json={
+                light_id: {"name": f"Light {light_id}", "state": {**state, "reachable": True}}
+                for light_id, state in light_states.items()
+            },
+        )
+    )
+
+
 @respx.mock
-async def test_update_zone_state(client):
-    action_route = respx.put(f"{BRIDGE_URL}/groups/z1/action").mock(
-        return_value=Response(200, json=[{"success": {"/groups/z1/action/bri": 127}}])
+async def test_update_zone_state_brightness_only_targets_on_lights(client):
+    _mock_zone_lights(
+        group_lights=["1", "2", "3"],
+        light_states={
+            "1": {"on": True, "bri": 100},
+            "2": {"on": False, "bri": 50},
+            "3": {"on": True, "bri": 200},
+        },
+    )
+    light1_route = respx.put(f"{BRIDGE_URL}/lights/1/state").mock(
+        return_value=Response(200, json=[{"success": {"/lights/1/state/bri": 127}}])
+    )
+    light2_route = respx.put(f"{BRIDGE_URL}/lights/2/state").mock(
+        return_value=Response(200, json=[{"success": {"/lights/2/state/bri": 127}}])
+    )
+    light3_route = respx.put(f"{BRIDGE_URL}/lights/3/state").mock(
+        return_value=Response(200, json=[{"success": {"/lights/3/state/bri": 127}}])
     )
 
     resp = await client.put("/api/zones/z1/state", json={"brightness_pct": 50})
 
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
-    assert json.loads(action_route.calls.last.request.content) == {"bri": 127}
+    assert json.loads(light1_route.calls.last.request.content) == {"bri": 127}
+    assert json.loads(light3_route.calls.last.request.content) == {"bri": 127}
+    assert light2_route.call_count == 0
 
 
 async def test_update_zone_state_neither_field_is_400(client):
@@ -39,6 +70,9 @@ async def test_update_zone_state_off(client):
 
 @respx.mock
 async def test_update_zone_state_on_and_brightness_pct_combine(client):
+    # An explicit `on` (the Off button, or the frontend's "drag up from a
+    # fully-off zone" gesture) still goes through the group action, applying
+    # to every light regardless of its current on/off state.
     action_route = respx.put(f"{BRIDGE_URL}/groups/z1/action").mock(
         return_value=Response(200, json=[{"success": {"/groups/z1/action/bri": 127}}])
     )
@@ -56,9 +90,20 @@ async def test_update_zone_state_out_of_range_brightness_pct_is_422(client):
 
 
 @respx.mock
-async def test_update_zone_state_bridge_error_returns_502(client):
+async def test_update_zone_state_off_bridge_error_returns_502(client):
     respx.put(f"{BRIDGE_URL}/groups/z1/action").mock(
         return_value=Response(200, json=[{"error": {"description": "invalid/missing parameters in body"}}])
+    )
+
+    resp = await client.put("/api/zones/z1/state", json={"on": False})
+
+    assert resp.status_code == 502
+
+
+@respx.mock
+async def test_update_zone_state_brightness_only_bridge_error_returns_502(client):
+    respx.get(f"{BRIDGE_URL}/groups/z1").mock(
+        return_value=Response(200, json=[{"error": {"description": "not found"}}])
     )
 
     resp = await client.put("/api/zones/z1/state", json={"brightness_pct": 50})

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -197,11 +197,16 @@
   // as a scene-specific brightness (issue #47) — this sets the zone's
   // brightness directly, independent of any scene. Errors are surfaced by
   // ZoneBrightnessSlider itself (it awaits this call), not stashed here.
-  // Dragging brightness up implies the zone is on, same as setLightBrightness
-  // does per-light — otherwise a light the Off button (or an earlier 0 drag)
-  // turned off would take the new bri without actually turning back on.
-  async function setZoneBrightness(zoneId, pct) {
-    await putJson(`/api/zones/${zoneId}/state`, { brightness_pct: pct, on: true })
+  //
+  // turnOn distinguishes two gestures that look the same (dragging the
+  // slider up) but should behave differently: turnOn is only set when the
+  // zone was fully off, where the drag is the explicit "turn the zone back
+  // on" gesture and should apply to every light. Otherwise (some lights
+  // already on) it's a plain brightness adjustment and must NOT force `on`
+  // — the backend then only touches lights that are already on, leaving any
+  // individually-off bulb in that zone alone rather than waking it up.
+  async function setZoneBrightness(zoneId, pct, { turnOn = false } = {}) {
+    await putJson(`/api/zones/${zoneId}/state`, { brightness_pct: pct, ...(turnOn ? { on: true } : {}) })
     await refreshLights()
   }
 

--- a/frontend/src/ZoneBrightnessSlider.svelte
+++ b/frontend/src/ZoneBrightnessSlider.svelte
@@ -45,9 +45,15 @@
   }
 
   // Dragging to 0 is an off command, not brightness_pct: 0 (the bridge
-  // rejects that) — everything above 0 sets brightness and implies on.
+  // rejects that). Dragging up from a fully-off zone is the explicit
+  // "turn back on" gesture and applies to every light (turnOn: true) —
+  // otherwise (some lights already on) it's a plain adjustment that must
+  // only touch the already-on lights, per onSetBrightness's contract.
   function setBrightness(pct) {
-    runUpdate(() => (pct === 0 ? onSetZoneOn(zone.id, false) : onSetBrightness(zone.id, pct)))
+    runUpdate(() => {
+      if (pct === 0) return onSetZoneOn(zone.id, false)
+      return onSetBrightness(zone.id, pct, { turnOn: off })
+    })
   }
 
   function turnOff() {


### PR DESCRIPTION
## Summary
- A plain drag on the zone brightness slider previously hit the group action endpoint, which set brightness for every light in the zone regardless of on/off state — so it could wake up a bulb the user had deliberately turned off individually.
- `set_zone_brightness_for_on_lights` now fetches the zone's current on/off state first and only PUTs brightness to lights that are already on; off lights are left completely untouched.
- The 0-boundary gesture from the previous PR is unchanged: dragging to 0 still turns the whole zone off (`{on: false}` via the group action), and dragging up from a **fully-off** zone still turns every light in it back on — that's still the only way back on, and it's the one case where the frontend explicitly sends `on: true` alongside the new brightness.

## Test plan
- [x] Backend test suite passes (49 tests), including new coverage asserting only on-light IDs receive a brightness PUT
- [x] `npm run build` succeeds with no new warnings
- [x] Manually verified against the real bridge: with a zone partially on (2 of 6 lights on), dragging the slider moved only the 2 on lights and left the other 4 off and untouched; turning the zone fully off then dragging up from 0 still turned all 6 back on