### PR TITLE
Add dynamic scene play/pause with speed control

### DIFF
--- a/backend/HUE_API.md
+++ b/backend/HUE_API.md
@@ -169,11 +169,50 @@ each so future-us doesn't have to re-derive it.
 | Capabilities | `GET /api/<username>/capabilities` | Not implementing — informational (resource limits like max scenes/groups); no current need to check quota before writes. |
 | Full datastore dump | `GET /api/<username>/` | Not implementing as a route — useful for debugging/exploration only, already covered ad hoc via `scripts/pair_bridge.py`-style scripts when needed. |
 
+## Dynamic scene playback (CLIP v2) (issue: play/pause a Scene, like the official app)
+
+CLIP v1 has no concept of animating between a scene's colors — that's a v2
+API entirely (`https://<bridge-ip>/clip/v2/resource/...`), which this app
+otherwise avoids (see Notes below). Only scenes with a multi-color
+`palette` can actually animate; the bridge doesn't reject `dynamic_palette`
+outright for a single-color scene, but there's nothing to cycle between.
+
+Auth is a header instead of a URL segment: `hue-application-key:
+<api_key>` (same `api_key` as v1 — one pairing covers both APIs). The
+bridge's cert is self-signed and scoped to its own identity, not its LAN
+IP, so hostname validation can never pass locally — the backend's v2 client
+uses `verify=False` (accepted practice for local bridge access; traffic is
+still encrypted, just not CA-validated).
+
+v2 resources are addressed by UUID, not v1's small integer ids, and
+there's no direct conversion. `GET /clip/v2/resource/scene` returns every
+scene with an `id_v1` field (e.g. `"/scenes/12"`) — the only documented way
+to resolve a v1 scene id to its v2 UUID. The backend does this lookup on
+every play/stop/speed call rather than caching the mapping, since the
+bridge doesn't expose any change-notification for it and correctness
+matters more than the extra round-trip for these convenience actions.
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/clip/v2/resource/scene` | List scenes (used here only to resolve `id_v1` -> UUID). |
+| PUT | `/clip/v2/resource/scene/<uuid>` | Body `{"recall": {"action": "dynamic_palette"}}` starts playback; `{"recall": {"action": "static"}}` stops it (re-applies the scene as a fixed snapshot — v2 has no separate "pause" verb); `{"speed": <0-1>}` adjusts animation speed. |
+
+**Confirmed against a real bridge**: `recall` and `speed` can't be set in
+the same PUT — combining them is rejected with `{"errors": [{"description":
+"Recall cannot be combined with modifying 'speed'"}]}`. Starting playback
+at a specific speed therefore takes two sequential PUTs: set `speed` first,
+then `recall.action: dynamic_palette` second.
+
+Unlike v1 (always 200, with an `[{"error": ...}]`-shaped body signaling
+failure), v2 uses real HTTP status codes for errors — a 400 with an
+`errors` array in the JSON body, checked via `raise_for_status()` alone.
+
 ## Notes
 
-- This is the CLIP v1 local API (plain HTTP, no cert handling needed), not
-  the newer CLIP v2/remote API. v1 is what `scripts/pair_bridge.py` already
-  pairs against and is sufficient for LAN-only proxying.
+- Aside from the dynamic-playback endpoints above, this app uses the CLIP
+  v1 local API (plain HTTP, no cert handling needed) rather than v2. v1 is
+  what `scripts/pair_bridge.py` pairs against and is sufficient for
+  LAN-only proxying of everything else.
 - The backend is the only thing that ever holds `<username>`/`api_key` —
   per the architecture in CLAUDE.md, the browser only talks to the backend,
   never directly to the bridge.

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -244,6 +244,101 @@ async def _bridge_request(
         return data
 
 
+async def _request_bridge_v2(
+    ip: str, api_key: str, path: str, *, method: str = "GET", json_body: Optional[dict] = None
+) -> dict:
+    """CLIP v2 request — different transport from CLIP v1's _request_bridge.
+
+    v2 is HTTPS-only with a self-signed cert scoped to the bridge's own
+    identity rather than its LAN IP, so cert hostname validation can never
+    pass here; verify=False is the standard/accepted approach for local
+    bridge access (traffic is still encrypted, just not CA-validated).
+    Auth is a header (hue-application-key) instead of a URL segment, and
+    unlike v1 (which always replies 200 with an embedded error list), v2
+    uses real HTTP status codes for errors — so raise_for_status() alone
+    covers what v1 needed the list-shaped-response check for.
+    """
+    url = f"https://{ip}/clip/v2/resource/{path}"
+    headers = {"hue-application-key": api_key}
+    async with httpx.AsyncClient(timeout=5.0, verify=False) as client:
+        resp = await client.request(method, url, json=json_body, headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def _bridge_request_v2(
+    config: BridgeConfig, path: str, *, method: str = "GET", json_body: Optional[dict] = None
+) -> dict:
+    """v2 counterpart to _bridge_request, deliberately without its
+    rediscovery/retry dance — this only backs the dynamic-scene
+    play/stop/speed convenience endpoints, not core control, so a stale IP
+    here just surfaces as a one-off error rather than being worth the added
+    complexity. The IP still self-heals via any v1 call's own rediscovery.
+    """
+    if not config.bridge_ip or not config.api_key:
+        raise BridgeNotConfigured()
+    try:
+        return await _request_bridge_v2(config.bridge_ip, config.api_key, path, method=method, json_body=json_body)
+    except httpx.HTTPStatusError as exc:
+        logger.warning("Bridge at %s rejected the v2 request: %s", config.bridge_ip, exc)
+        raise BridgeUnreachable("bridge rejected the request") from exc
+    except httpx.HTTPError as exc:
+        logger.warning("Could not reach bridge (v2) at %s: %s", config.bridge_ip, exc)
+        raise BridgeUnreachable("could not reach the bridge") from exc
+
+
+async def _v2_scene_uuid(config: BridgeConfig, scene_id: str) -> str:
+    """Resolve a v1 scene id (what the rest of this app uses) to its v2 UUID.
+
+    CLIP v2 resources are addressed by UUID, not the small integer ids v1
+    uses — there's no direct conversion, only this lookup. Each v2 scene
+    carries its origin v1 id back as `id_v1` (e.g. "/scenes/12"), which is
+    the only documented way to bridge the two id spaces.
+    """
+    data = await _bridge_request_v2(config, "scene")
+    target = f"/scenes/{scene_id}"
+    for item in data.get("data", []):
+        if item.get("id_v1") == target:
+            return item["id"]
+    raise BridgeUnreachable(f"scene {scene_id} has no CLIP v2 counterpart")
+
+
+async def play_scene(config: BridgeConfig, scene_id: str, speed: float) -> None:
+    """Start the scene's dynamic palette animation (the official app's "play").
+
+    CLIP v1 has no concept of this at all — only v2's `dynamic_palette`
+    recall action animates between a scene's palette colors. Scenes without
+    a multi-color palette will have the bridge reject this; that surfaces as
+    a normal BridgeUnreachable, same as any other rejected write.
+
+    Confirmed against a real bridge: `recall` and `speed` can't be set in
+    the same PUT — the bridge rejects it with "Recall cannot be combined
+    with modifying 'speed'" (error unrelated to palette support). So this
+    sets speed first, then triggers playback in a second PUT.
+    """
+    uuid = await _v2_scene_uuid(config, scene_id)
+    await _bridge_request_v2(config, f"scene/{uuid}", method="PUT", json_body={"speed": speed})
+    await _bridge_request_v2(
+        config, f"scene/{uuid}", method="PUT", json_body={"recall": {"action": "dynamic_palette"}}
+    )
+
+
+async def stop_scene(config: BridgeConfig, scene_id: str) -> None:
+    """Stop the dynamic animation by re-recalling the scene statically.
+
+    v2 has no separate "pause" verb — `static` re-applies the scene's
+    stored colors as a fixed snapshot, which is what halts the cycling.
+    """
+    uuid = await _v2_scene_uuid(config, scene_id)
+    await _bridge_request_v2(config, f"scene/{uuid}", method="PUT", json_body={"recall": {"action": "static"}})
+
+
+async def set_scene_speed(config: BridgeConfig, scene_id: str, speed: float) -> None:
+    """Adjust the animation speed of a currently-playing dynamic scene."""
+    uuid = await _v2_scene_uuid(config, scene_id)
+    await _bridge_request_v2(config, f"scene/{uuid}", method="PUT", json_body={"speed": speed})
+
+
 async def get_lights(config: BridgeConfig) -> list[Light]:
     data = await _bridge_request(config, "lights")
     return [_to_light(light_id, raw) for light_id, raw in data.items()]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,9 +20,12 @@ from app.hue_client import (
     get_lights,
     get_scenes,
     get_zones,
+    play_scene,
     set_group_state,
     set_light_state,
+    set_scene_speed,
     set_zone_brightness_for_on_lights,
+    stop_scene,
 )
 
 app = FastAPI(title="Hue Light Control API")
@@ -145,6 +148,37 @@ class SceneActivateRequest(BaseModel):
 async def activate_scene_route(scene_id: str, body: SceneActivateRequest):
     config = load_config()
     await activate_scene(config, body.group_id, scene_id)
+    return {"status": "ok"}
+
+
+class ScenePlayRequest(BaseModel):
+    # CLIP v2's speed range is 0-1; 0.5 mirrors the official app's default
+    # slider position for a scene that hasn't been played before.
+    speed: float = Field(default=0.5, ge=0, le=1)
+
+
+class SceneSpeedRequest(BaseModel):
+    speed: float = Field(..., ge=0, le=1)
+
+
+@app.post("/api/scenes/{scene_id}/play")
+async def play_scene_route(scene_id: str, body: ScenePlayRequest = ScenePlayRequest()):
+    config = load_config()
+    await play_scene(config, scene_id, body.speed)
+    return {"status": "ok"}
+
+
+@app.post("/api/scenes/{scene_id}/stop")
+async def stop_scene_route(scene_id: str):
+    config = load_config()
+    await stop_scene(config, scene_id)
+    return {"status": "ok"}
+
+
+@app.put("/api/scenes/{scene_id}/speed")
+async def set_scene_speed_route(scene_id: str, body: SceneSpeedRequest):
+    config = load_config()
+    await set_scene_speed(config, scene_id, body.speed)
     return {"status": "ok"}
 
 

--- a/backend/tests/test_scene_dynamic.py
+++ b/backend/tests/test_scene_dynamic.py
@@ -1,0 +1,99 @@
+import json
+
+import respx
+from httpx import Response
+
+V2_BASE = "https://192.168.x.x/clip/v2/resource"
+
+SCENE_LIST_RESPONSE = {
+    "errors": [],
+    "data": [
+        {"id": "uuid-1", "id_v1": "/scenes/abc123"},
+        {"id": "uuid-2", "id_v1": "/scenes/other"},
+    ],
+}
+
+
+@respx.mock
+async def test_play_scene(client):
+    respx.get(f"{V2_BASE}/scene").mock(return_value=Response(200, json=SCENE_LIST_RESPONSE))
+    put_route = respx.put(f"{V2_BASE}/scene/uuid-1").mock(return_value=Response(200, json={"errors": [], "data": []}))
+
+    resp = await client.post("/api/scenes/abc123/play", json={"speed": 0.75})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    # Two separate PUTs — the bridge rejects `recall` and `speed` combined
+    # in one request (see play_scene's docstring).
+    bodies = [json.loads(call.request.content) for call in put_route.calls]
+    assert bodies == [{"speed": 0.75}, {"recall": {"action": "dynamic_palette"}}]
+
+
+@respx.mock
+async def test_play_scene_default_speed(client):
+    respx.get(f"{V2_BASE}/scene").mock(return_value=Response(200, json=SCENE_LIST_RESPONSE))
+    put_route = respx.put(f"{V2_BASE}/scene/uuid-1").mock(return_value=Response(200, json={"errors": [], "data": []}))
+
+    resp = await client.post("/api/scenes/abc123/play", json={})
+
+    assert resp.status_code == 200
+    assert json.loads(put_route.calls[0].request.content) == {"speed": 0.5}
+
+
+@respx.mock
+async def test_stop_scene(client):
+    respx.get(f"{V2_BASE}/scene").mock(return_value=Response(200, json=SCENE_LIST_RESPONSE))
+    put_route = respx.put(f"{V2_BASE}/scene/uuid-1").mock(return_value=Response(200, json={"errors": [], "data": []}))
+
+    resp = await client.post("/api/scenes/abc123/stop")
+
+    assert resp.status_code == 200
+    assert json.loads(put_route.calls.last.request.content) == {"recall": {"action": "static"}}
+
+
+@respx.mock
+async def test_set_scene_speed(client):
+    respx.get(f"{V2_BASE}/scene").mock(return_value=Response(200, json=SCENE_LIST_RESPONSE))
+    put_route = respx.put(f"{V2_BASE}/scene/uuid-1").mock(return_value=Response(200, json={"errors": [], "data": []}))
+
+    resp = await client.put("/api/scenes/abc123/speed", json={"speed": 0.2})
+
+    assert resp.status_code == 200
+    assert json.loads(put_route.calls.last.request.content) == {"speed": 0.2}
+
+
+async def test_set_scene_speed_out_of_range_is_422(client):
+    resp = await client.put("/api/scenes/abc123/speed", json={"speed": 1.5})
+
+    assert resp.status_code == 422
+
+
+@respx.mock
+async def test_play_scene_unknown_id_returns_502(client):
+    respx.get(f"{V2_BASE}/scene").mock(return_value=Response(200, json=SCENE_LIST_RESPONSE))
+
+    resp = await client.post("/api/scenes/nonexistent/play", json={})
+
+    assert resp.status_code == 502
+
+
+async def test_play_scene_bridge_not_configured_returns_503(client, monkeypatch):
+    from app.config import BridgeConfig
+
+    monkeypatch.setattr("app.main.load_config", lambda: BridgeConfig())
+
+    resp = await client.post("/api/scenes/abc123/play", json={})
+
+    assert resp.status_code == 503
+
+
+@respx.mock
+async def test_play_scene_bridge_rejects_returns_502(client):
+    respx.get(f"{V2_BASE}/scene").mock(return_value=Response(200, json=SCENE_LIST_RESPONSE))
+    respx.put(f"{V2_BASE}/scene/uuid-1").mock(
+        return_value=Response(400, json={"errors": [{"description": "not supported"}], "data": []})
+    )
+
+    resp = await client.post("/api/scenes/abc123/play", json={})
+
+    assert resp.status_code == 502

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -214,6 +214,22 @@
     await putJson(`/api/zones/${zoneId}/state`, { on })
     await refreshLights()
   }
+
+  // Play/stop/speed are dynamic-palette-only (CLIP v2) and don't affect the
+  // v1-derived `lights` array the way activate/toggle do, so unlike
+  // activateScene these don't refreshLights afterward — the resulting
+  // per-color animation isn't representable in that model anyway.
+  async function playScene(sceneId, speed) {
+    await postJson(`/api/scenes/${sceneId}/play`, { speed })
+  }
+
+  async function stopScene(sceneId) {
+    await postJson(`/api/scenes/${sceneId}/stop`, {})
+  }
+
+  async function setSceneSpeed(sceneId, speed) {
+    await putJson(`/api/scenes/${sceneId}/speed`, { speed })
+  }
 </script>
 
 <main>
@@ -280,7 +296,13 @@
             {:else}
               <div class="grid">
                 {#each group.scenes as scene (scene.id)}
-                  <SceneCard {scene} onActivate={activateScene} />
+                  <SceneCard
+                    {scene}
+                    onActivate={activateScene}
+                    onPlay={playScene}
+                    onStop={stopScene}
+                    onSpeedChange={setSceneSpeed}
+                  />
                 {/each}
               </div>
             {/if}

--- a/frontend/src/SceneCard.svelte
+++ b/frontend/src/SceneCard.svelte
@@ -1,5 +1,7 @@
 <script>
-  let { scene, onActivate } = $props()
+  import BrightnessSlider from './BrightnessSlider.svelte'
+
+  let { scene, onActivate, onPlay, onStop, onSpeedChange } = $props()
 
   // Standalone LightScenes (no group_id) can't be activated via the
   // group-action endpoint (see HUE_API.md's Scenes section) — render them
@@ -20,21 +22,108 @@
       pending = false
     }
   }
+
+  // The card used to be a single <button>, but it now contains a nested
+  // play/stop <button> and a range input — both invalid/unreliable inside
+  // a <button> element (the HTML parser doesn't actually nest a <button>
+  // inside another). It's a role="button" div instead, with the same
+  // keyboard activation (Enter/Space) a real button gets for free.
+  function activateOnKey(event) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      activate()
+    }
+  }
+
+  // Whether this scene's dynamic palette animation is currently playing.
+  // The bridge has no v1-visible "is this scene animating" state (same gap
+  // get_scenes documents for on/off/brightness), and checking it via v2
+  // would mean a per-scene poll — so this is tracked client-side, optimistic
+  // on a successful play/stop, same pattern as toggleLight's optimistic on.
+  let playing = $state(false)
+  let playPending = $state(false)
+  let playError = $state(null)
+  let speed = $state(0.5)
+
+  async function togglePlay(event) {
+    event.stopPropagation()
+    if (playPending) return
+    playPending = true
+    playError = null
+    try {
+      if (playing) {
+        await onStop(scene.id)
+        playing = false
+      } else {
+        await onPlay(scene.id, speed)
+        playing = true
+      }
+    } catch (err) {
+      playError = err.message
+    } finally {
+      playPending = false
+    }
+  }
+
+  async function changeSpeed(value) {
+    const pct = Number(value)
+    speed = pct / 100
+    try {
+      await onSpeedChange(scene.id, speed)
+    } catch (err) {
+      playError = err.message
+    }
+  }
 </script>
 
 <div class="card" class:inactive={!activatable}>
-  <button
-    type="button"
+  <div
     class="activate"
-    disabled={!activatable || pending}
+    class:disabled={!activatable || pending}
+    role="button"
+    tabindex={activatable && !pending ? 0 : -1}
+    aria-disabled={!activatable || pending}
     title={activatable ? undefined : "Can't activate — not part of a zone"}
     onclick={() => activate()}
+    onkeydown={activateOnKey}
   >
-    <span class="name">{scene.name}</span>
+    <span class="name-row">
+      <span class="name">{scene.name}</span>
+      <button
+        type="button"
+        class="play-toggle"
+        class:playing
+        disabled={playPending}
+        title={playing ? 'Stop dynamic effect' : 'Play dynamic effect'}
+        onclick={togglePlay}
+      >
+        {playing ? '⏸' : '▶'}
+      </button>
+    </span>
+    {#if playing}
+      <div
+        class="speed-row"
+        role="group"
+        aria-label="{scene.name} speed control"
+        onclick={(e) => e.stopPropagation()}
+        onkeydown={(e) => e.stopPropagation()}
+      >
+        <BrightnessSlider
+          value={Math.round(speed * 100)}
+          label="{scene.name} speed"
+          min={0}
+          showValue={false}
+          onChange={changeSpeed}
+        />
+      </div>
+    {/if}
     {#if scene.activateError}
       <span class="badge error-badge">{scene.activateError}</span>
     {/if}
-  </button>
+    {#if playError}
+      <span class="badge error-badge">{playError}</span>
+    {/if}
+  </div>
 </div>
 
 <style>
@@ -77,7 +166,7 @@
     cursor: pointer;
   }
 
-  .activate:hover:not(:disabled) {
+  .activate:hover:not(.disabled) {
     filter: brightness(0.97);
   }
 
@@ -86,12 +175,54 @@
     outline-offset: -2px;
   }
 
-  .activate:disabled {
+  .activate.disabled {
     cursor: default;
+  }
+
+  .name-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    width: 100%;
   }
 
   .name {
     font-weight: 600;
+  }
+
+  .play-toggle {
+    flex-shrink: 0;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 50%;
+    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    background: light-dark(#f4f4f4, #2a2a2a);
+    font-size: 0.75rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: inherit;
+  }
+
+  .play-toggle:hover:not(:disabled) {
+    filter: brightness(0.95);
+  }
+
+  .play-toggle:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
+  .play-toggle.playing {
+    background: light-dark(#dff0e0, #1f3a26);
+    border-color: light-dark(#9fd6a8, #2f5a3b);
+  }
+
+  .speed-row {
+    width: 100%;
   }
 
   .badge {

--- a/frontend/src/SceneCard.svelte
+++ b/frontend/src/SceneCard.svelte
@@ -18,6 +18,13 @@
     pending = true
     try {
       await onActivate(scene.id, scene.group_id)
+      // A v1 scene recall statically re-applies the scene's stored light
+      // states (see HUE_API.md), which halts any v2 dynamic animation
+      // already running on those bulbs — so activating the card while
+      // playing must also drop the client-side playing flag, or the UI
+      // keeps showing a pause icon/speed slider for an animation that's
+      // no longer actually running.
+      playing = false
     } finally {
       pending = false
     }
@@ -45,6 +52,14 @@
   let playError = $state(null)
   let speed = $state(0.5)
 
+  // Stops both click and keydown from reaching the outer card's
+  // activate handler — needed on both event types since a keyboard
+  // Enter/Space on this button dispatches a keydown that would otherwise
+  // bubble to the card's onkeydown and also recall the whole scene.
+  function stopBubble(event) {
+    event.stopPropagation()
+  }
+
   async function togglePlay(event) {
     event.stopPropagation()
     if (playPending) return
@@ -65,13 +80,20 @@
     }
   }
 
+  // Same "only the latest request wins" guard App.svelte's
+  // setLightBrightness uses for the identical race: rapid successive
+  // speed changes can leave overlapping PUTs in flight, and an older one
+  // failing after a newer one already succeeded shouldn't stomp playError.
+  let latestSpeedRequest = 0
+
   async function changeSpeed(value) {
     const pct = Number(value)
     speed = pct / 100
+    const token = ++latestSpeedRequest
     try {
       await onSpeedChange(scene.id, speed)
     } catch (err) {
-      playError = err.message
+      if (latestSpeedRequest === token) playError = err.message
     }
   }
 </script>
@@ -96,6 +118,7 @@
         disabled={playPending}
         title={playing ? 'Stop dynamic effect' : 'Play dynamic effect'}
         onclick={togglePlay}
+        onkeydown={stopBubble}
       >
         {playing ? '⏸' : '▶'}
       </button>
@@ -105,8 +128,8 @@
         class="speed-row"
         role="group"
         aria-label="{scene.name} speed control"
-        onclick={(e) => e.stopPropagation()}
-        onkeydown={(e) => e.stopPropagation()}
+        onclick={stopBubble}
+        onkeydown={stopBubble}
       >
         <BrightnessSlider
           value={Math.round(speed * 100)}


### PR DESCRIPTION
## Summary
- Adds CLIP v2 support for dynamic scene playback (the official Hue app's play/pause), which doesn't exist in the CLIP v1 API this backend otherwise uses.
- New backend endpoints: `POST /api/scenes/{id}/play`, `POST /api/scenes/{id}/stop`, `PUT /api/scenes/{id}/speed`.
- Resolves each scene's v1 id to its v2 UUID on demand via `id_v1`; v2 client uses HTTPS with `verify=False` (standard for the bridge's self-signed, non-IP-scoped cert).
- Frontend: play/stop toggle on every scene card, with a speed slider that only appears while playing.

## Test plan
- [x] `pytest` — 57 passed (including new `test_scene_dynamic.py`)
- [x] `vite build` — clean, no new warnings
- [x] Manually verified play → speed change → stop against the real bridge (curl)
- [x] Manually verified in browser (screenshots): play toggle, speed slider appearing/collapsing, stop reverting state, no interference with the outer scene-activate click target

🤖 Generated with [Claude Code](https://claude.com/claude-code)