### PR TITLE
Fix scene play/pause status to reflect real bridge state

### DIFF
--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -404,9 +404,15 @@ async def get_scenes(config: BridgeConfig) -> list[Scene]:
 
 
 async def _get_v2_scenes_by_v1_id_or_empty(config: BridgeConfig) -> dict[str, dict]:
+    # Deliberately broad except: playing/speed are a nice-to-have overlay
+    # (see get_scenes), so *anything* going wrong here — not just the
+    # BridgeNotConfigured/BridgeUnreachable cases _bridge_request_v2 itself
+    # raises, but e.g. a malformed/truncated 200 response from a flaky
+    # bridge that resp.json() can't parse — must degrade to "not playing"
+    # rather than 500ing the entire scene list.
     try:
         return await _get_v2_scenes_by_v1_id(config)
-    except (BridgeNotConfigured, BridgeUnreachable):
+    except Exception:
         logger.warning("Could not fetch CLIP v2 scene status; scenes will report not-playing", exc_info=True)
         return {}
 

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -41,6 +41,16 @@ class Scene(BaseModel):
     light_count: int
     light_ids: list[str] = []
     group_id: Optional[str] = None
+    # Ground truth from CLIP v2's per-scene `status.active` (see get_scenes) —
+    # not a guess. Some scenes are authored with `auto_dynamic: true` (set via
+    # the official app), which makes a plain v1 activate/recall start the
+    # dynamic palette animation immediately, with no separate "play" step —
+    # `playing` reflects that even though this app's own /play endpoint was
+    # never called. speed is CLIP v2's 0-1 animation speed, present on every
+    # scene (not just currently-playing ones) since the bridge remembers the
+    # last speed it was set to.
+    playing: bool = False
+    speed: float = 0.5
 
 
 class Zone(BaseModel):
@@ -287,20 +297,25 @@ async def _bridge_request_v2(
         raise BridgeUnreachable("could not reach the bridge") from exc
 
 
-async def _v2_scene_uuid(config: BridgeConfig, scene_id: str) -> str:
-    """Resolve a v1 scene id (what the rest of this app uses) to its v2 UUID.
+async def _get_v2_scenes_by_v1_id(config: BridgeConfig) -> dict[str, dict]:
+    """Fetch every v2 scene resource, indexed by its origin v1 id (e.g. "/scenes/12").
 
     CLIP v2 resources are addressed by UUID, not the small integer ids v1
-    uses — there's no direct conversion, only this lookup. Each v2 scene
-    carries its origin v1 id back as `id_v1` (e.g. "/scenes/12"), which is
-    the only documented way to bridge the two id spaces.
+    uses — there's no direct conversion, only this lookup, and the bridge
+    only offers it as a bulk listing (no "get by v1 id" filter), so one
+    call here covers every scene rather than one round-trip per scene.
     """
     data = await _bridge_request_v2(config, "scene")
-    target = f"/scenes/{scene_id}"
-    for item in data.get("data", []):
-        if item.get("id_v1") == target:
-            return item["id"]
-    raise BridgeUnreachable(f"scene {scene_id} has no CLIP v2 counterpart")
+    return {item["id_v1"]: item for item in data.get("data", []) if "id_v1" in item}
+
+
+async def _v2_scene_uuid(config: BridgeConfig, scene_id: str) -> str:
+    """Resolve a v1 scene id (what the rest of this app uses) to its v2 UUID."""
+    by_v1_id = await _get_v2_scenes_by_v1_id(config)
+    item = by_v1_id.get(f"/scenes/{scene_id}")
+    if item is None:
+        raise BridgeUnreachable(f"scene {scene_id} has no CLIP v2 counterpart")
+    return item["id"]
 
 
 async def play_scene(config: BridgeConfig, scene_id: str, speed: float) -> None:
@@ -344,8 +359,9 @@ async def get_lights(config: BridgeConfig) -> list[Light]:
     return [_to_light(light_id, raw) for light_id, raw in data.items()]
 
 
-def _to_scene(scene_id: str, raw: dict) -> Scene:
+def _to_scene(scene_id: str, raw: dict, v2_item: Optional[dict] = None) -> Scene:
     light_ids = raw.get("lights", [])
+    v2_item = v2_item or {}
     return Scene(
         id=scene_id,
         name=raw.get("name", f"Scene {scene_id}"),
@@ -354,6 +370,8 @@ def _to_scene(scene_id: str, raw: dict) -> Scene:
         # Only GroupScenes have this; ties the scene to the group (room/zone)
         # it was created for. Absent for standalone LightScenes.
         group_id=raw.get("group"),
+        playing=v2_item.get("status", {}).get("active") == "dynamic_palette",
+        speed=v2_item.get("speed", 0.5),
     )
 
 
@@ -361,21 +379,36 @@ async def get_scenes(config: BridgeConfig) -> list[Scene]:
     # A scene's *stored* brightness (from GET /scenes/<id>'s lightstates)
     # reflects whatever it looked like when created/last saved — not
     # whether it's currently applied or what its lights are actually at
-    # right now. There's no bridge concept of "is this scene active" at
-    # all (confirmed: group.action never records which scene, if any, was
-    # last recalled). So this deliberately doesn't fetch per-scene detail —
-    # the frontend instead derives each scene's live on/off + brightness by
-    # matching light_ids against the already-loaded /api/lights, which is
-    # both actually correct (reflects reality, not a stale snapshot) and
-    # cheaper (no per-scene bridge round-trip at all).
-    data = await _bridge_request(config, "scenes")
+    # right now. The frontend derives each scene's live on/off + brightness
+    # by matching light_ids against the already-loaded /api/lights instead of
+    # trusting this stored snapshot.
+    #
+    # "Is this scene playing" is different: v1 has no such concept, but
+    # CLIP v2's per-scene `status.active` does — including reflecting scenes
+    # that started animating on their own (an `auto_dynamic` scene recalled
+    # the ordinary v1 way). So unlike the on/off+brightness case above, this
+    # fetches v2 detail for every scene, in one bulk call. A v2 failure
+    # (e.g. the bridge is momentarily only reachable over v1) degrades to
+    # every scene reporting not-playing rather than failing the whole list —
+    # playing/speed are a nice-to-have overlay, not core scene data.
+    v1_data, v2_by_v1_id = await asyncio.gather(
+        _bridge_request(config, "scenes"), _get_v2_scenes_by_v1_id_or_empty(config)
+    )
     return [
-        _to_scene(scene_id, raw)
-        for scene_id, raw in data.items()
+        _to_scene(scene_id, raw, v2_by_v1_id.get(f"/scenes/{scene_id}"))
+        for scene_id, raw in v1_data.items()
         # "Recycle" scenes are bridge-internal, created by apps to save/restore
         # state (e.g. before a light effect) — not scenes a user created.
         if not raw.get("recycle", False)
     ]
+
+
+async def _get_v2_scenes_by_v1_id_or_empty(config: BridgeConfig) -> dict[str, dict]:
+    try:
+        return await _get_v2_scenes_by_v1_id(config)
+    except (BridgeNotConfigured, BridgeUnreachable):
+        logger.warning("Could not fetch CLIP v2 scene status; scenes will report not-playing", exc_info=True)
+        return {}
 
 
 def _to_zone(group_id: str, raw: dict) -> Zone:

--- a/backend/tests/test_existing_routes.py
+++ b/backend/tests/test_existing_routes.py
@@ -95,6 +95,25 @@ async def test_list_scenes_v2_unreachable_defaults_to_not_playing(client):
 
 
 @respx.mock
+async def test_list_scenes_v2_malformed_response_defaults_to_not_playing(client):
+    # A 200 with unparseable JSON — a flaky-bridge scenario, not one of the
+    # HTTP-status/network errors _bridge_request_v2 itself turns into
+    # BridgeUnreachable — must still degrade gracefully rather than 500ing
+    # the whole /api/scenes response (see _get_v2_scenes_by_v1_id_or_empty).
+    respx.get(f"{BRIDGE_URL}/scenes").mock(
+        return_value=Response(200, json={"s1": {"name": "Relax", "lights": ["1"], "group": "3"}})
+    )
+    respx.get(f"{V2_BASE}/scene").mock(return_value=Response(200, content=b"not json"))
+
+    resp = await client.get("/api/scenes")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body[0]["playing"] is False
+    assert body[0]["speed"] == 0.5
+
+
+@respx.mock
 async def test_list_zones(client):
     respx.get(f"{BRIDGE_URL}/groups").mock(
         return_value=Response(

--- a/backend/tests/test_existing_routes.py
+++ b/backend/tests/test_existing_routes.py
@@ -4,6 +4,7 @@ from httpx import Response
 from app.config import BridgeConfig
 
 BRIDGE_URL = "http://192.168.x.x/api/test-api-key"
+V2_BASE = "https://192.168.x.x/clip/v2/resource"
 
 
 @respx.mock
@@ -46,17 +47,51 @@ async def test_list_scenes(client):
             },
         )
     )
+    # Deliberately no per-scene detail beyond brightness/on-off, which the
+    # frontend derives by matching light_ids against /api/lights instead
+    # (v1 has no concept of "is this scene active"). playing/speed do come
+    # from a per-scene CLIP v2 lookup though — s1 here is mid-animation.
+    respx.get(f"{V2_BASE}/scene").mock(
+        return_value=Response(
+            200,
+            json={
+                "errors": [],
+                "data": [
+                    {"id_v1": "/scenes/s1", "status": {"active": "dynamic_palette"}, "speed": 0.75},
+                ],
+            },
+        )
+    )
 
     resp = await client.get("/api/scenes")
 
     assert resp.status_code == 200
-    # Deliberately no brightness/on-off here — get_scenes doesn't fetch
-    # per-scene detail at all. The frontend derives live brightness/on-off
-    # by matching light_ids against /api/lights instead, since the bridge
-    # has no concept of "is this scene active" (see hue_client.get_scenes).
     assert resp.json() == [
-        {"id": "s1", "name": "Relax", "light_count": 2, "light_ids": ["1", "2"], "group_id": "3"},
+        {
+            "id": "s1",
+            "name": "Relax",
+            "light_count": 2,
+            "light_ids": ["1", "2"],
+            "group_id": "3",
+            "playing": True,
+            "speed": 0.75,
+        },
     ]
+
+
+@respx.mock
+async def test_list_scenes_v2_unreachable_defaults_to_not_playing(client):
+    respx.get(f"{BRIDGE_URL}/scenes").mock(
+        return_value=Response(200, json={"s1": {"name": "Relax", "lights": ["1"], "group": "3"}})
+    )
+    respx.get(f"{V2_BASE}/scene").mock(return_value=Response(500))
+
+    resp = await client.get("/api/scenes")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body[0]["playing"] is False
+    assert body[0]["speed"] == 0.5
 
 
 @respx.mock

--- a/backend/tests/test_scene_create.py
+++ b/backend/tests/test_scene_create.py
@@ -37,6 +37,11 @@ async def test_create_group_scene(client):
         "light_count": 3,
         "light_ids": ["1", "2", "5"],
         "group_id": "3",
+        # Newly-created scenes are never playing and default to
+        # get_scenes'/Scene's standard speed — this route builds the
+        # response directly, no CLIP v2 lookup involved.
+        "playing": False,
+        "speed": 0.5,
     }
 
 
@@ -61,6 +66,8 @@ async def test_create_light_scene_without_group(client):
         "light_count": 2,
         "light_ids": ["1", "2"],
         "group_id": None,
+        "playing": False,
+        "speed": 0.5,
     }
 
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -212,6 +212,10 @@
     const scene = scenes.find((s) => s.id === sceneId)
     if (!scene) return
     scene.activateError = null
+    // Also clears any stale play/stop/speed error — a fresh activate makes
+    // whatever previously failed there moot, and refreshScenes below is
+    // about to report the current real state regardless.
+    scene.playError = null
     try {
       await postJson(`/api/scenes/${sceneId}/activate`, { group_id: groupId })
       // Also resyncs playing/speed, not just lights: a recall can itself
@@ -255,18 +259,30 @@
   // set them the same way toggleLight optimistically sets light.on, and
   // revert + surface scene.playError on failure. SceneCard reads
   // scene.playing/scene.speed directly rather than tracking its own copy.
+  //
+  // All three share one latest-request-wins guard, same pattern (and same
+  // reason) as setLightBrightness's latestBrightnessRequest: they all touch
+  // the same scene.playing/scene.speed fields, so e.g. a slow /play POST
+  // failing after a since-succeeded speed drag must not revert that newer
+  // speed — not just an older speed change racing a newer one.
+  const latestSceneRequest = new Map()
+
   async function playScene(sceneId, speed) {
     const scene = scenes.find((s) => s.id === sceneId)
     if (!scene) return
     const prev = { playing: scene.playing, speed: scene.speed }
+    const token = Symbol()
+    latestSceneRequest.set(sceneId, token)
     scene.playing = true
     scene.speed = speed
     scene.playError = null
     try {
       await postJson(`/api/scenes/${sceneId}/play`, { speed })
     } catch (err) {
-      Object.assign(scene, prev)
-      scene.playError = err.message
+      if (latestSceneRequest.get(sceneId) === token) {
+        Object.assign(scene, prev)
+        scene.playError = err.message
+      }
     }
   }
 
@@ -274,33 +290,31 @@
     const scene = scenes.find((s) => s.id === sceneId)
     if (!scene) return
     const prev = scene.playing
+    const token = Symbol()
+    latestSceneRequest.set(sceneId, token)
     scene.playing = false
     scene.playError = null
     try {
       await postJson(`/api/scenes/${sceneId}/stop`, {})
     } catch (err) {
-      scene.playing = prev
-      scene.playError = err.message
+      if (latestSceneRequest.get(sceneId) === token) {
+        scene.playing = prev
+        scene.playError = err.message
+      }
     }
   }
-
-  // Latest-request-wins guard, same pattern (and same reason) as
-  // setLightBrightness's latestBrightnessRequest: rapid successive speed
-  // drags can leave overlapping PUTs in flight, and an older one failing
-  // after a newer one already succeeded shouldn't stomp the newer value.
-  const latestSpeedRequest = new Map()
 
   async function setSceneSpeed(sceneId, speed) {
     const scene = scenes.find((s) => s.id === sceneId)
     if (!scene) return
     const prev = scene.speed
     const token = Symbol()
-    latestSpeedRequest.set(sceneId, token)
+    latestSceneRequest.set(sceneId, token)
     scene.speed = speed
     try {
       await putJson(`/api/scenes/${sceneId}/speed`, { speed })
     } catch (err) {
-      if (latestSpeedRequest.get(sceneId) === token) {
+      if (latestSceneRequest.get(sceneId) === token) {
         scene.speed = prev
         scene.playError = err.message
       }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -75,6 +75,33 @@
     }
   }
 
+  // Same silent-refetch-and-merge shape as refreshLights, and for the same
+  // reason: a scene's playing/speed (from CLIP v2's status.active, see
+  // hue_client.get_scenes) can change on the bridge as a side effect of a
+  // plain v1 activate — scenes authored with auto_dynamic start animating
+  // immediately, with no play button involved — so activateScene needs a
+  // way to resync without a loading-state flicker across the whole list.
+  // Merges into existing scene objects in place, same reasoning as
+  // refreshLights: playScene/stopScene/setSceneSpeed capture a specific
+  // scene object by reference for their own optimistic-update-with-revert,
+  // and a wholesale array replacement here could detach one mid-flight.
+  async function refreshScenes() {
+    try {
+      const fresh = await fetchJson('/api/scenes')
+      const existingById = new Map(scenes.map((scene) => [scene.id, scene]))
+      for (const updated of fresh) {
+        const existing = existingById.get(updated.id)
+        if (existing) {
+          Object.assign(existing, updated)
+        } else {
+          scenes.push(updated)
+        }
+      }
+    } catch {
+      // Leave the last-known scenes in place — same reasoning as refreshLights.
+    }
+  }
+
   async function loadZones() {
     zonesLoading = true
     zonesError = null
@@ -187,7 +214,10 @@
     scene.activateError = null
     try {
       await postJson(`/api/scenes/${sceneId}/activate`, { group_id: groupId })
-      await refreshLights()
+      // Also resyncs playing/speed, not just lights: a recall can itself
+      // start a dynamic animation for an auto_dynamic scene (see
+      // refreshScenes), which this app has no way to predict client-side.
+      await Promise.all([refreshLights(), refreshScenes()])
     } catch (err) {
       scene.activateError = err.message
     }
@@ -219,16 +249,62 @@
   // v1-derived `lights` array the way activate/toggle do, so unlike
   // activateScene these don't refreshLights afterward — the resulting
   // per-color animation isn't representable in that model anyway.
+  //
+  // scene.playing/scene.speed are the bridge's own CLIP v2 status (see
+  // hue_client.get_scenes) — not a client guess — so these optimistically
+  // set them the same way toggleLight optimistically sets light.on, and
+  // revert + surface scene.playError on failure. SceneCard reads
+  // scene.playing/scene.speed directly rather than tracking its own copy.
   async function playScene(sceneId, speed) {
-    await postJson(`/api/scenes/${sceneId}/play`, { speed })
+    const scene = scenes.find((s) => s.id === sceneId)
+    if (!scene) return
+    const prev = { playing: scene.playing, speed: scene.speed }
+    scene.playing = true
+    scene.speed = speed
+    scene.playError = null
+    try {
+      await postJson(`/api/scenes/${sceneId}/play`, { speed })
+    } catch (err) {
+      Object.assign(scene, prev)
+      scene.playError = err.message
+    }
   }
 
   async function stopScene(sceneId) {
-    await postJson(`/api/scenes/${sceneId}/stop`, {})
+    const scene = scenes.find((s) => s.id === sceneId)
+    if (!scene) return
+    const prev = scene.playing
+    scene.playing = false
+    scene.playError = null
+    try {
+      await postJson(`/api/scenes/${sceneId}/stop`, {})
+    } catch (err) {
+      scene.playing = prev
+      scene.playError = err.message
+    }
   }
 
+  // Latest-request-wins guard, same pattern (and same reason) as
+  // setLightBrightness's latestBrightnessRequest: rapid successive speed
+  // drags can leave overlapping PUTs in flight, and an older one failing
+  // after a newer one already succeeded shouldn't stomp the newer value.
+  const latestSpeedRequest = new Map()
+
   async function setSceneSpeed(sceneId, speed) {
-    await putJson(`/api/scenes/${sceneId}/speed`, { speed })
+    const scene = scenes.find((s) => s.id === sceneId)
+    if (!scene) return
+    const prev = scene.speed
+    const token = Symbol()
+    latestSpeedRequest.set(sceneId, token)
+    scene.speed = speed
+    try {
+      await putJson(`/api/scenes/${sceneId}/speed`, { speed })
+    } catch (err) {
+      if (latestSpeedRequest.get(sceneId) === token) {
+        scene.speed = prev
+        scene.playError = err.message
+      }
+    }
   }
 </script>
 

--- a/frontend/src/SceneCard.svelte
+++ b/frontend/src/SceneCard.svelte
@@ -17,14 +17,12 @@
     if (pending || !activatable) return
     pending = true
     try {
+      // onActivate also refreshes this scene's playing/speed from the
+      // bridge afterward — a plain v1 recall can itself start a dynamic
+      // animation for scenes authored with `auto_dynamic: true` (see
+      // App.svelte's activateScene), so `scene.playing` isn't something
+      // this card can infer client-side; it has to ask the bridge.
       await onActivate(scene.id, scene.group_id)
-      // A v1 scene recall statically re-applies the scene's stored light
-      // states (see HUE_API.md), which halts any v2 dynamic animation
-      // already running on those bulbs — so activating the card while
-      // playing must also drop the client-side playing flag, or the UI
-      // keeps showing a pause icon/speed slider for an animation that's
-      // no longer actually running.
-      playing = false
     } finally {
       pending = false
     }
@@ -42,15 +40,15 @@
     }
   }
 
-  // Whether this scene's dynamic palette animation is currently playing.
-  // The bridge has no v1-visible "is this scene animating" state (same gap
-  // get_scenes documents for on/off/brightness), and checking it via v2
-  // would mean a per-scene poll — so this is tracked client-side, optimistic
-  // on a successful play/stop, same pattern as toggleLight's optimistic on.
-  let playing = $state(false)
+  // scene.playing/scene.speed are bridge ground truth (CLIP v2's
+  // status.active — see hue_client.get_scenes), not a client guess: some
+  // scenes are authored with auto_dynamic and start animating from a plain
+  // activate, with no play button involved, so this card can't derive
+  // "is it playing" on its own. onPlay/onStop/onSpeedChange (App.svelte)
+  // own the optimistic mutation of the scene object and revert-on-error;
+  // this card just reflects scene.playing/scene.speed and tracks its own
+  // in-flight state for disabling the button mid-request.
   let playPending = $state(false)
-  let playError = $state(null)
-  let speed = $state(0.5)
 
   // Stops both click and keydown from reaching the outer card's
   // activate handler — needed on both event types since a keyboard
@@ -64,37 +62,19 @@
     event.stopPropagation()
     if (playPending) return
     playPending = true
-    playError = null
     try {
-      if (playing) {
+      if (scene.playing) {
         await onStop(scene.id)
-        playing = false
       } else {
-        await onPlay(scene.id, speed)
-        playing = true
+        await onPlay(scene.id, scene.speed ?? 0.5)
       }
-    } catch (err) {
-      playError = err.message
     } finally {
       playPending = false
     }
   }
 
-  // Same "only the latest request wins" guard App.svelte's
-  // setLightBrightness uses for the identical race: rapid successive
-  // speed changes can leave overlapping PUTs in flight, and an older one
-  // failing after a newer one already succeeded shouldn't stomp playError.
-  let latestSpeedRequest = 0
-
-  async function changeSpeed(value) {
-    const pct = Number(value)
-    speed = pct / 100
-    const token = ++latestSpeedRequest
-    try {
-      await onSpeedChange(scene.id, speed)
-    } catch (err) {
-      if (latestSpeedRequest === token) playError = err.message
-    }
+  function changeSpeed(value) {
+    onSpeedChange(scene.id, Number(value) / 100)
   }
 </script>
 
@@ -114,16 +94,16 @@
       <button
         type="button"
         class="play-toggle"
-        class:playing
+        class:playing={scene.playing}
         disabled={playPending}
-        title={playing ? 'Stop dynamic effect' : 'Play dynamic effect'}
+        title={scene.playing ? 'Stop dynamic effect' : 'Play dynamic effect'}
         onclick={togglePlay}
         onkeydown={stopBubble}
       >
-        {playing ? '⏸' : '▶'}
+        {scene.playing ? '⏸' : '▶'}
       </button>
     </span>
-    {#if playing}
+    {#if scene.playing}
       <div
         class="speed-row"
         role="group"
@@ -132,7 +112,7 @@
         onkeydown={stopBubble}
       >
         <BrightnessSlider
-          value={Math.round(speed * 100)}
+          value={Math.round((scene.speed ?? 0.5) * 100)}
           label="{scene.name} speed"
           min={0}
           showValue={false}
@@ -143,8 +123,8 @@
     {#if scene.activateError}
       <span class="badge error-badge">{scene.activateError}</span>
     {/if}
-    {#if playError}
-      <span class="badge error-badge">{playError}</span>
+    {#if scene.playError}
+      <span class="badge error-badge">{scene.playError}</span>
     {/if}
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Fixes an inaccuracy reported after #54 shipped: scenes authored with CLIP v2's `auto_dynamic` flag start animating as soon as they're activated (the plain scene-card click), with no separate "play" step — but the frontend's play/pause indicator and speed slider were purely optimistic client-side state, so those scenes showed as "not playing" right after activation even though they were animating on the bridge.
- `GET /api/scenes` now merges in each scene's real CLIP v2 `status.active`/`speed` via one bulk v2 lookup (gracefully degrades to not-playing if v2 is momentarily unreachable, rather than failing the whole scene list).
- `activateScene` now refreshes scene state afterward so the play indicator reflects reality post-activate.
- `playScene`/`stopScene`/`setSceneSpeed` moved their optimistic-update-with-revert logic into `App.svelte`, mutating the shared scene object directly — same pattern as `toggleLight`/`setLightBrightness` — instead of `SceneCard` tracking its own (now provably wrong) local copy.

## Test plan
- [x] `pytest` — 58 passed, including new coverage for `playing`/`speed` in the scene list and v2-unreachable degradation
- [x] `vite build` — clean, same pre-existing unrelated warnings as `main`
- [x] Manually confirmed against the real bridge: activated an `auto_dynamic` scene via the card body (not the play button) and confirmed the UI immediately showed the pause icon + speed slider, matching the bridge's actual `dynamic_palette` status; stopped it via the UI and confirmed it reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)