### PR TITLE
Widen layout and align Bulbs/Scenes headers

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -451,6 +451,7 @@
 
   .bulbs-panel h2,
   .scenes-section h2 {
+    margin: 0 0 1.25rem;
     font-size: 1.15rem;
     letter-spacing: -0.01em;
   }
@@ -469,7 +470,7 @@
   }
 
   .section-header h2 {
-    margin: 0;
+    margin: 0 0 1.25rem;
   }
 
   .zone-group-footer button {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -469,10 +469,6 @@
     gap: 1rem;
   }
 
-  .section-header h2 {
-    margin: 0 0 1.25rem;
-  }
-
   .zone-group-footer button {
     font: inherit;
     font-size: 0.85rem;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -17,7 +17,7 @@ body {
 }
 
 main {
-  max-width: 60rem;
+  max-width: 90rem;
   margin: 0 auto;
   padding: 2rem;
 }


### PR DESCRIPTION
## Summary
- Increase main content max-width from 60rem to 90rem to use more of the page
- Align Bulbs and Scenes section headers vertically, with equal spacing to their first content row

## Test plan
- [x] Verified visually in browser: headers align, spacing matches, wider layout renders correctly