### PR TITLE
Collapsible zones + virtual Favorites zone

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,10 @@ CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.yaml"
 class BridgeConfig(BaseModel):
     bridge_ip: Optional[str] = None
     api_key: Optional[str] = None
+    # Favorited scene ids (issue #58) — local UI preference, not bridge
+    # data, so it lives alongside bridge_ip/api_key in the same local config
+    # rather than requiring a separate store.
+    favorite_scene_ids: list[str] = []
 
 
 def load_config() -> BridgeConfig:
@@ -22,9 +26,7 @@ def load_config() -> BridgeConfig:
     return BridgeConfig(**data)
 
 
-def update_bridge_ip(ip: str) -> None:
-    config = load_config()
-    config.bridge_ip = ip
+def _write_config(config: BridgeConfig) -> None:
     # Write-then-rename so a crash mid-write can't leave config.yaml
     # truncated (which would also lose api_key, requiring re-pairing).
     fd, tmp_path = tempfile.mkstemp(dir=CONFIG_PATH.parent, prefix=".config.yaml.")
@@ -36,3 +38,15 @@ def update_bridge_ip(ip: str) -> None:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
         raise
+
+
+def update_bridge_ip(ip: str) -> None:
+    config = load_config()
+    config.bridge_ip = ip
+    _write_config(config)
+
+
+def update_favorite_scene_ids(scene_ids: list[str]) -> None:
+    config = load_config()
+    config.favorite_scene_ids = scene_ids
+    _write_config(config)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from app.config import load_config
+from app.config import load_config, update_favorite_scene_ids
 from app.hue_client import (
     BridgeNotConfigured,
     BridgeUnreachable,
@@ -179,6 +179,24 @@ async def stop_scene_route(scene_id: str):
 async def set_scene_speed_route(scene_id: str, body: SceneSpeedRequest):
     config = load_config()
     await set_scene_speed(config, scene_id, body.speed)
+    return {"status": "ok"}
+
+
+class FavoritesUpdate(BaseModel):
+    scene_ids: list[str]
+
+
+@app.get("/api/favorites")
+def list_favorites() -> list[str]:
+    # Local UI preference, not bridge data — works even when the bridge
+    # isn't configured, unlike the scene/zone/light routes.
+    config = load_config()
+    return config.favorite_scene_ids
+
+
+@app.put("/api/favorites")
+def update_favorites(body: FavoritesUpdate):
+    update_favorite_scene_ids(body.scene_ids)
     return {"status": "ok"}
 
 

--- a/backend/tests/test_favorites_routes.py
+++ b/backend/tests/test_favorites_routes.py
@@ -1,0 +1,48 @@
+from app.config import BridgeConfig
+
+
+async def test_list_favorites_returns_configured_ids(client, monkeypatch):
+    monkeypatch.setattr(
+        "app.main.load_config",
+        lambda: BridgeConfig(bridge_ip="192.168.x.x", api_key="test-api-key", favorite_scene_ids=["s1", "s2"]),
+    )
+
+    resp = await client.get("/api/favorites")
+
+    assert resp.status_code == 200
+    assert resp.json() == ["s1", "s2"]
+
+
+async def test_list_favorites_empty_by_default(client):
+    resp = await client.get("/api/favorites")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_list_favorites_works_without_bridge_configured(client, monkeypatch):
+    # Favorites are a local UI preference, not bridge data — unlike
+    # /api/lights etc, this shouldn't 503 just because the bridge isn't set up.
+    monkeypatch.setattr("app.main.load_config", lambda: BridgeConfig())
+
+    resp = await client.get("/api/favorites")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_update_favorites_persists_ids(client, monkeypatch):
+    saved = {}
+    monkeypatch.setattr("app.main.update_favorite_scene_ids", lambda scene_ids: saved.setdefault("ids", scene_ids))
+
+    resp = await client.put("/api/favorites", json={"scene_ids": ["s1", "s3"]})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    assert saved["ids"] == ["s1", "s3"]
+
+
+async def test_update_favorites_missing_field_is_422(client):
+    resp = await client.put("/api/favorites", json={})
+
+    assert resp.status_code == 422

--- a/frontend/src/AddFavoriteForm.svelte
+++ b/frontend/src/AddFavoriteForm.svelte
@@ -1,0 +1,186 @@
+<script>
+  import { onMount } from 'svelte'
+
+  // scenes not already in Favorites — the caller (App.svelte) filters this
+  // down before passing it in, same division of labor as CreateSceneForm.
+  let { scenes, onAdd, onClose } = $props()
+
+  let dialog = $state(null)
+  let selectedIds = $state([])
+  let submitting = $state(false)
+  let error = $state(null)
+
+  let canSubmit = $derived(selectedIds.length > 0 && !submitting)
+
+  onMount(() => {
+    dialog?.showModal()
+  })
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    if (!canSubmit) return
+    submitting = true
+    error = null
+    try {
+      await onAdd(selectedIds)
+      dialog?.close()
+    } catch (err) {
+      error = err.message
+      submitting = false
+    }
+  }
+
+  function handleBackdropClick(event) {
+    // Same coordinate-based backdrop check as CreateSceneForm — a click
+    // landing in the dialog's own padding also reports target === dialog.
+    const rect = dialog.getBoundingClientRect()
+    const outside =
+      event.clientX < rect.left ||
+      event.clientX > rect.right ||
+      event.clientY < rect.top ||
+      event.clientY > rect.bottom
+    if (outside) {
+      dialog.close()
+    }
+  }
+</script>
+
+<dialog bind:this={dialog} onclose={onClose} onclick={handleBackdropClick}>
+  <form onsubmit={handleSubmit}>
+    <h2>Add to Favorites</h2>
+
+    {#if scenes.length === 0}
+      <p class="hint">Every scene is already in Favorites.</p>
+    {:else}
+      <fieldset class="field">
+        <legend>Scenes</legend>
+        <div class="scene-list">
+          {#each scenes as scene (scene.id)}
+            <label class="scene-option">
+              <input type="checkbox" bind:group={selectedIds} value={scene.id} />
+              {scene.name}
+            </label>
+          {/each}
+        </div>
+      </fieldset>
+    {/if}
+
+    {#if error}
+      <p class="error">{error}</p>
+    {/if}
+
+    <div class="actions">
+      <button type="button" onclick={() => dialog?.close()}>Cancel</button>
+      <button type="submit" class="primary" disabled={!canSubmit}>
+        {submitting ? 'Adding…' : 'Add'}
+      </button>
+    </div>
+  </form>
+</dialog>
+
+<style>
+  dialog {
+    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+    background: light-dark(#fff, #1e1e1e);
+    color: inherit;
+    width: min(24rem, 90vw);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  }
+
+  dialog::backdrop {
+    background: rgba(0, 0, 0, 0.4);
+  }
+
+  button.primary:hover:not(:disabled) {
+    filter: brightness(1.08);
+  }
+
+  .actions button:not(.primary):hover {
+    filter: brightness(0.95);
+  }
+
+  h2 {
+    margin: 0 0 1rem;
+    font-size: 1.1rem;
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .field legend {
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0;
+  }
+
+  .scene-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    max-height: 14rem;
+    overflow-y: auto;
+    padding: 0.5rem;
+    border-radius: 0.5rem;
+    background: light-dark(#f7f7f7, #262626);
+  }
+
+  .scene-option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  .hint {
+    font-size: 0.8rem;
+    color: light-dark(#666, #aaa);
+    margin: 0;
+  }
+
+  .error {
+    font-size: 0.85rem;
+    color: light-dark(#a3392c, #f0958a);
+    margin: 0;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  button {
+    font: inherit;
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    background: light-dark(#eee, #333);
+    color: inherit;
+    cursor: pointer;
+  }
+
+  button.primary {
+    background: light-dark(#1c7a2e, #1f3d24);
+    color: light-dark(#fff, #7fe396);
+    border-color: transparent;
+  }
+
+  button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -4,6 +4,7 @@
   import SceneCard from './SceneCard.svelte'
   import ZoneBrightnessSlider from './ZoneBrightnessSlider.svelte'
   import CreateSceneForm from './CreateSceneForm.svelte'
+  import AddFavoriteForm from './AddFavoriteForm.svelte'
   import { fetchJson, postJson, putJson } from './api.js'
 
   let lights = $state([])
@@ -17,6 +18,22 @@
   let zones = $state([])
   let zonesLoading = $state(true)
   let zonesError = $state(null)
+
+  // Favorited scene ids (issue #58) — a local UI preference stored server-
+  // side (see backend/app/main.py's /api/favorites), not bridge data. A
+  // load failure degrades to "no favorites" rather than blocking the rest
+  // of the page, same treatment as zonesError below.
+  let favoriteSceneIds = $state([])
+  let favoritesError = $state(null)
+
+  async function loadFavorites() {
+    favoritesError = null
+    try {
+      favoriteSceneIds = await fetchJson('/api/favorites')
+    } catch (err) {
+      favoritesError = err.message
+    }
+  }
 
   // Persisted so the panel stays collapsed/expanded across reloads rather
   // than resetting every time the app is opened. localStorage access is
@@ -140,6 +157,7 @@
     loadLights()
     loadScenes()
     loadZones()
+    loadFavorites()
   })
 
   // Buckets scenes under the zone they belong to. Scenes tied to a Room, an
@@ -149,6 +167,15 @@
   // so its "New Scene" button (issue #30) has somewhere to live; "Other"
   // isn't a real zone (no per-zone create button applies to it) and is
   // dropped when empty.
+  //
+  // Favorites (issue #58) is a virtual zone prepended ahead of every real
+  // one: not backed by a bridge group (isZone: false, so it gets no
+  // ZoneBrightnessSlider — there's no single set of bulbs to control), but
+  // always kept like a real zone (its own "+ Add" button needs somewhere to
+  // live even with zero favorites yet). Its scenes are the actual Scene
+  // objects from `scenes`, in favoriteSceneIds order, so activating one
+  // still goes through that scene's own real group_id — Favorites is just a
+  // curated view, not a separate copy.
   let zoneGroups = $derived.by(() => {
     const byId = new Map(
       zones.map((zone) => [
@@ -161,8 +188,32 @@
       const group = byId.get(scene.group_id) ?? other
       group.scenes.push(scene)
     }
-    return [...byId.values(), other].filter((group) => group.isZone || group.scenes.length > 0)
+    const scenesById = new Map(scenes.map((scene) => [scene.id, scene]))
+    const favorites = {
+      id: 'favorites',
+      name: 'Favorites',
+      scenes: favoriteSceneIds.map((id) => scenesById.get(id)).filter(Boolean),
+      isZone: false,
+      isFavorites: true,
+    }
+    return [favorites, ...byId.values(), other].filter(
+      (group) => group.isZone || group.isFavorites || group.scenes.length > 0
+    )
   })
+
+  // Per-zone-group collapse state (issue #57), keyed by group id. Absent
+  // means "use the default" rather than "expanded" — Favorites defaults
+  // open, everything else defaults collapsed (issue #58) — so a group only
+  // needs an entry here once the user has actually toggled it.
+  let collapsedGroupIds = $state({})
+
+  function isGroupCollapsed(groupId) {
+    return collapsedGroupIds[groupId] ?? groupId !== 'favorites'
+  }
+
+  function toggleGroupCollapsed(groupId) {
+    collapsedGroupIds[groupId] = !isGroupCollapsed(groupId)
+  }
 
   // Note: a bridge write can succeed here (200) for a light that's
   // temporarily unreachable — Hue queues state changes for offline Zigbee
@@ -224,6 +275,22 @@
   async function createScene(name, lightIds, groupId) {
     const scene = await postJson('/api/scenes', { name, light_ids: lightIds, group_id: groupId })
     scenes = [...scenes, scene]
+  }
+
+  // Whether the "Add to Favorites" dialog is open (issue #58's Favorites
+  // footer button — same one-dialog-at-a-time shape as createFormZone).
+  let addFavoriteFormOpen = $state(false)
+
+  async function addFavorites(sceneIds) {
+    const updated = [...new Set([...favoriteSceneIds, ...sceneIds])]
+    await putJson('/api/favorites', { scene_ids: updated })
+    favoriteSceneIds = updated
+  }
+
+  async function removeFavorite(sceneId) {
+    const updated = favoriteSceneIds.filter((id) => id !== sceneId)
+    await putJson('/api/favorites', { scene_ids: updated })
+    favoriteSceneIds = updated
   }
 
   // Unlike toggleLight, there's no meaningful "prior value" to optimistically
@@ -392,6 +459,13 @@
           onClose={() => (createFormZone = null)}
         />
       {/if}
+      {#if addFavoriteFormOpen}
+        <AddFavoriteForm
+          scenes={scenes.filter((scene) => !favoriteSceneIds.includes(scene.id))}
+          onAdd={addFavorites}
+          onClose={() => (addFavoriteFormOpen = false)}
+        />
+      {/if}
       {#if scenesLoading || zonesLoading}
         <p>Loading scenes…</p>
       {:else if scenesError}
@@ -404,36 +478,60 @@
             <button onclick={loadZones}>Retry</button>
           </p>
         {/if}
+        {#if favoritesError}
+          <p class="error">
+            Couldn't load favorites ({favoritesError}).
+            <button onclick={loadFavorites}>Retry</button>
+          </p>
+        {/if}
         {#if zoneGroups.length === 0}
           <p>No scenes found.</p>
         {/if}
         {#each zoneGroups as group (group.id)}
           <div class="zone-group">
             <div class="zone-header">
+              <button
+                class="collapse-toggle"
+                onclick={() => toggleGroupCollapsed(group.id)}
+                aria-expanded={!isGroupCollapsed(group.id)}
+                aria-label={isGroupCollapsed(group.id) ? `Expand ${group.name}` : `Collapse ${group.name}`}
+              >
+                <span class="chevron" class:collapsed={isGroupCollapsed(group.id)}>▾</span>
+              </button>
               <h3>{group.name}</h3>
               {#if group.isZone}
                 <ZoneBrightnessSlider zone={group} {lights} onSetBrightness={setZoneBrightness} onSetZoneOn={setZoneOn} />
               {/if}
             </div>
-            {#if group.scenes.length === 0}
-              <p class="hint">No scenes in this zone yet.</p>
-            {:else}
-              <div class="grid">
-                {#each group.scenes as scene (scene.id)}
-                  <SceneCard
-                    {scene}
-                    onActivate={activateScene}
-                    onPlay={playScene}
-                    onStop={stopScene}
-                    onSpeedChange={setSceneSpeed}
-                  />
-                {/each}
-              </div>
-            {/if}
-            {#if group.isZone}
-              <div class="zone-group-footer">
-                <button onclick={() => (createFormZone = group)}>+ New Scene</button>
-              </div>
+            {#if !isGroupCollapsed(group.id)}
+              {#if group.scenes.length === 0}
+                <p class="hint">
+                  {group.isFavorites ? 'No favorite scenes yet.' : 'No scenes in this zone yet.'}
+                </p>
+              {:else}
+                <div class="grid">
+                  {#each group.scenes as scene (scene.id)}
+                    <SceneCard
+                      {scene}
+                      onActivate={activateScene}
+                      onPlay={playScene}
+                      onStop={stopScene}
+                      onSpeedChange={setSceneSpeed}
+                      onRemoveFavorite={group.isFavorites ? removeFavorite : undefined}
+                    />
+                  {/each}
+                </div>
+              {/if}
+              {#if group.isZone}
+                <div class="zone-group-footer">
+                  <button onclick={() => (createFormZone = group)}>+ New Scene</button>
+                </div>
+              {/if}
+              {#if group.isFavorites}
+                <div class="zone-group-footer">
+                  <button onclick={() => (addFavoriteFormOpen = true)}>+ Add</button>
+                </div>
+              {/if}
             {/if}
           </div>
         {/each}

--- a/frontend/src/SceneCard.svelte
+++ b/frontend/src/SceneCard.svelte
@@ -1,7 +1,10 @@
 <script>
   import BrightnessSlider from './BrightnessSlider.svelte'
 
-  let { scene, onActivate, onPlay, onStop, onSpeedChange } = $props()
+  // onRemoveFavorite, when set, renders a small remove button (issue #58) —
+  // only passed by App.svelte for cards rendered inside the Favorites group,
+  // never for a scene's "home" zone card.
+  let { scene, onActivate, onPlay, onStop, onSpeedChange, onRemoveFavorite } = $props()
 
   // Standalone LightScenes (no group_id) can't be activated via the
   // group-action endpoint (see HUE_API.md's Scenes section) — render them
@@ -76,6 +79,22 @@
   function changeSpeed(value) {
     onSpeedChange(scene.id, Number(value) / 100)
   }
+
+  let removePending = $state(false)
+  let removeError = $state(null)
+
+  async function removeFavorite(event) {
+    event.stopPropagation()
+    if (removePending) return
+    removePending = true
+    removeError = null
+    try {
+      await onRemoveFavorite(scene.id)
+    } catch (err) {
+      removeError = err.message
+      removePending = false
+    }
+  }
 </script>
 
 <div class="card" class:inactive={!activatable}>
@@ -91,17 +110,31 @@
   >
     <span class="name-row">
       <span class="name">{scene.name}</span>
-      <button
-        type="button"
-        class="play-toggle"
-        class:playing={scene.playing}
-        disabled={playPending}
-        title={scene.playing ? 'Stop dynamic effect' : 'Play dynamic effect'}
-        onclick={togglePlay}
-        onkeydown={stopBubble}
-      >
-        {scene.playing ? '⏸' : '▶'}
-      </button>
+      <span class="card-actions">
+        <button
+          type="button"
+          class="play-toggle"
+          class:playing={scene.playing}
+          disabled={playPending}
+          title={scene.playing ? 'Stop dynamic effect' : 'Play dynamic effect'}
+          onclick={togglePlay}
+          onkeydown={stopBubble}
+        >
+          {scene.playing ? '⏸' : '▶'}
+        </button>
+        {#if onRemoveFavorite}
+          <button
+            type="button"
+            class="remove-favorite"
+            disabled={removePending}
+            title="Remove from Favorites"
+            onclick={removeFavorite}
+            onkeydown={stopBubble}
+          >
+            ✕
+          </button>
+        {/if}
+      </span>
     </span>
     {#if scene.playing}
       <div
@@ -125,6 +158,9 @@
     {/if}
     {#if scene.playError}
       <span class="badge error-badge">{scene.playError}</span>
+    {/if}
+    {#if removeError}
+      <span class="badge error-badge">{removeError}</span>
     {/if}
   </div>
 </div>
@@ -192,6 +228,39 @@
 
   .name {
     font-weight: 600;
+  }
+
+  .card-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-shrink: 0;
+  }
+
+  .remove-favorite {
+    flex-shrink: 0;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 50%;
+    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    background: light-dark(#f4f4f4, #2a2a2a);
+    font-size: 0.7rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: inherit;
+  }
+
+  .remove-favorite:hover:not(:disabled) {
+    filter: brightness(0.95);
+    color: light-dark(#a3392c, #f0958a);
+  }
+
+  .remove-favorite:disabled {
+    opacity: 0.55;
+    cursor: default;
   }
 
   .play-toggle {


### PR DESCRIPTION
## Summary
- Every zone group (real zones, Other, and the new Favorites group) gets a collapse/expand toggle. Favorites starts expanded, everything else starts collapsed (#57, #58).
- Adds a virtual "Favorites" zone above all real zones: a curated list of existing scenes from any zone, with a "+ Add" dialog to pick scenes and a per-card remove (✕) button. Activating a favorited scene still goes through its own real group_id — Favorites is a view, not a copy.
- Favorite scene ids persist server-side via new `GET`/`PUT /api/favorites` endpoints, stored in `config.yaml` alongside bridge_ip/api_key.

Closes #57
Closes #58

## Test plan
- [x] Backend: `pytest` — 64 passed, including new `test_favorites_routes.py`
- [x] Frontend: `npm run build` succeeds
- [x] Manually verified in browser: Favorites starts expanded with an empty state and Add button; real zones start collapsed; adding a scene via the dialog shows it in Favorites and persists across reload; removing it via ✕ works and persists; expanding a real zone still shows its brightness slider, scenes, and New Scene button