### PR TITLE
Fix favorites race condition and dedupe dialog code

### DIFF
--- a/frontend/src/AddFavoriteForm.svelte
+++ b/frontend/src/AddFavoriteForm.svelte
@@ -1,20 +1,16 @@
 <script>
-  import { onMount } from 'svelte'
+  import FormDialog from './FormDialog.svelte'
 
   // scenes not already in Favorites — the caller (App.svelte) filters this
   // down before passing it in, same division of labor as CreateSceneForm.
   let { scenes, onAdd, onClose } = $props()
 
-  let dialog = $state(null)
+  let dialogEl = $state(null)
   let selectedIds = $state([])
   let submitting = $state(false)
   let error = $state(null)
 
   let canSubmit = $derived(selectedIds.length > 0 && !submitting)
-
-  onMount(() => {
-    dialog?.showModal()
-  })
 
   async function handleSubmit(event) {
     event.preventDefault()
@@ -23,30 +19,16 @@
     error = null
     try {
       await onAdd(selectedIds)
-      dialog?.close()
+      dialogEl?.close()
     } catch (err) {
       error = err.message
       submitting = false
     }
   }
-
-  function handleBackdropClick(event) {
-    // Same coordinate-based backdrop check as CreateSceneForm — a click
-    // landing in the dialog's own padding also reports target === dialog.
-    const rect = dialog.getBoundingClientRect()
-    const outside =
-      event.clientX < rect.left ||
-      event.clientX > rect.right ||
-      event.clientY < rect.top ||
-      event.clientY > rect.bottom
-    if (outside) {
-      dialog.close()
-    }
-  }
 </script>
 
-<dialog bind:this={dialog} onclose={onClose} onclick={handleBackdropClick}>
-  <form onsubmit={handleSubmit}>
+<FormDialog bind:dialogEl {onClose}>
+  <form class="dialog-form" onsubmit={handleSubmit}>
     <h2>Add to Favorites</h2>
 
     {#if scenes.length === 0}
@@ -54,9 +36,9 @@
     {:else}
       <fieldset class="field">
         <legend>Scenes</legend>
-        <div class="scene-list">
+        <div class="option-list tall">
           {#each scenes as scene (scene.id)}
-            <label class="scene-option">
+            <label class="option-row">
               <input type="checkbox" bind:group={selectedIds} value={scene.id} />
               {scene.name}
             </label>
@@ -70,117 +52,10 @@
     {/if}
 
     <div class="actions">
-      <button type="button" onclick={() => dialog?.close()}>Cancel</button>
+      <button type="button" onclick={() => dialogEl?.close()}>Cancel</button>
       <button type="submit" class="primary" disabled={!canSubmit}>
         {submitting ? 'Adding…' : 'Add'}
       </button>
     </div>
   </form>
-</dialog>
-
-<style>
-  dialog {
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
-    border-radius: 0.75rem;
-    padding: 1.25rem;
-    background: light-dark(#fff, #1e1e1e);
-    color: inherit;
-    width: min(24rem, 90vw);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
-  }
-
-  dialog::backdrop {
-    background: rgba(0, 0, 0, 0.4);
-  }
-
-  button.primary:hover:not(:disabled) {
-    filter: brightness(1.08);
-  }
-
-  .actions button:not(.primary):hover {
-    filter: brightness(0.95);
-  }
-
-  h2 {
-    margin: 0 0 1rem;
-    font-size: 1.1rem;
-  }
-
-  form {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .field {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-    border: none;
-    padding: 0;
-    margin: 0;
-  }
-
-  .field legend {
-    font-size: 0.85rem;
-    font-weight: 600;
-    padding: 0;
-  }
-
-  .scene-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-    max-height: 14rem;
-    overflow-y: auto;
-    padding: 0.5rem;
-    border-radius: 0.5rem;
-    background: light-dark(#f7f7f7, #262626);
-  }
-
-  .scene-option {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.9rem;
-  }
-
-  .hint {
-    font-size: 0.8rem;
-    color: light-dark(#666, #aaa);
-    margin: 0;
-  }
-
-  .error {
-    font-size: 0.85rem;
-    color: light-dark(#a3392c, #f0958a);
-    margin: 0;
-  }
-
-  .actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-  }
-
-  button {
-    font: inherit;
-    padding: 0.4rem 0.9rem;
-    border-radius: 999px;
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
-    background: light-dark(#eee, #333);
-    color: inherit;
-    cursor: pointer;
-  }
-
-  button.primary {
-    background: light-dark(#1c7a2e, #1f3d24);
-    color: light-dark(#fff, #7fe396);
-    border-color: transparent;
-  }
-
-  button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-</style>
+</FormDialog>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -281,16 +281,36 @@
   // footer button — same one-dialog-at-a-time shape as createFormZone).
   let addFavoriteFormOpen = $state(false)
 
+  // addFavorites/removeFavorite can be triggered from independent controls
+  // (the Add dialog, and a remove button on each favorited SceneCard) that
+  // don't share an in-flight guard the way a single control's own
+  // pending/submitting flag would. Without serializing, two overlapping
+  // calls would each compute `updated` from the same stale favoriteSceneIds
+  // snapshot, and whichever PUT resolves last would silently overwrite the
+  // other's change (both locally and in the persisted config.yaml). Queuing
+  // every mutation onto one promise chain ensures each only runs (and reads
+  // favoriteSceneIds) after the previous one has fully applied.
+  let favoritesQueue = Promise.resolve()
+
+  function queueFavoritesUpdate(computeUpdated) {
+    const run = favoritesQueue.then(async () => {
+      const updated = computeUpdated(favoriteSceneIds)
+      await putJson('/api/favorites', { scene_ids: updated })
+      favoriteSceneIds = updated
+    })
+    // Keep the chain alive even after a failed update — the caller below
+    // still sees the rejection via `run`, but the *next* queued mutation
+    // shouldn't be blocked forever by an earlier one's error.
+    favoritesQueue = run.catch(() => {})
+    return run
+  }
+
   async function addFavorites(sceneIds) {
-    const updated = [...new Set([...favoriteSceneIds, ...sceneIds])]
-    await putJson('/api/favorites', { scene_ids: updated })
-    favoriteSceneIds = updated
+    await queueFavoritesUpdate((current) => [...new Set([...current, ...sceneIds])])
   }
 
   async function removeFavorite(sceneId) {
-    const updated = favoriteSceneIds.filter((id) => id !== sceneId)
-    await putJson('/api/favorites', { scene_ids: updated })
-    favoriteSceneIds = updated
+    await queueFavoritesUpdate((current) => current.filter((id) => id !== sceneId))
   }
 
   // Unlike toggleLight, there's no meaningful "prior value" to optimistically

--- a/frontend/src/CreateSceneForm.svelte
+++ b/frontend/src/CreateSceneForm.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onMount } from 'svelte'
+  import FormDialog from './FormDialog.svelte'
 
   // fixedZone, when set, pins the scene to that zone (issue #30's per-zone
   // "New Scene" button) — the zone dropdown and light checkboxes below are
@@ -7,7 +7,7 @@
   // actual membership (see the hint text and HUE_API.md).
   let { lights, zones, fixedZone = null, onCreate, onClose } = $props()
 
-  let dialog = $state(null)
+  let dialogEl = $state(null)
   let name = $state('')
   let selectedLightIds = $state([])
   let selectedZoneId = $state(fixedZone?.id ?? '')
@@ -22,10 +22,6 @@
     name.trim().length > 0 && (selectedZoneId || selectedLightIds.length > 0) && !submitting
   )
 
-  onMount(() => {
-    dialog?.showModal()
-  })
-
   async function handleSubmit(event) {
     event.preventDefault()
     if (!canSubmit) return
@@ -33,35 +29,16 @@
     error = null
     try {
       await onCreate(name.trim(), selectedLightIds, selectedZoneId || null)
-      dialog?.close()
+      dialogEl?.close()
     } catch (err) {
       error = err.message
       submitting = false
     }
   }
-
-  function handleBackdropClick(event) {
-    // Any click that doesn't land on a child element (backdrop AND the
-    // dialog's own padding around <form>) reports target === dialog — so
-    // that check alone can't tell a real backdrop click from one that
-    // landed in the card's padding (visually still inside the card).
-    // Compare coordinates against the dialog's own rendered box instead
-    // (its border box, which includes the padding): only a click outside
-    // that box is a real click on the backdrop.
-    const rect = dialog.getBoundingClientRect()
-    const outside =
-      event.clientX < rect.left ||
-      event.clientX > rect.right ||
-      event.clientY < rect.top ||
-      event.clientY > rect.bottom
-    if (outside) {
-      dialog.close()
-    }
-  }
 </script>
 
-<dialog bind:this={dialog} onclose={onClose} onclick={handleBackdropClick}>
-  <form onsubmit={handleSubmit}>
+<FormDialog bind:dialogEl {onClose}>
+  <form class="dialog-form" onsubmit={handleSubmit}>
     <h2>{fixedZone ? `New Scene — ${fixedZone.name}` : 'New Scene'}</h2>
 
     <label class="field">
@@ -79,9 +56,9 @@
         {#if lights.length === 0}
           <p class="hint">No lights available.</p>
         {:else}
-          <div class="light-list">
+          <div class="option-list">
             {#each lights as light (light.id)}
-              <label class="light-option">
+              <label class="option-row">
                 <input type="checkbox" bind:group={selectedLightIds} value={light.id} />
                 {light.name}
               </label>
@@ -113,128 +90,10 @@
     {/if}
 
     <div class="actions">
-      <button type="button" onclick={() => dialog?.close()}>Cancel</button>
+      <button type="button" onclick={() => dialogEl?.close()}>Cancel</button>
       <button type="submit" class="primary" disabled={!canSubmit}>
         {submitting ? 'Creating…' : 'Create Scene'}
       </button>
     </div>
   </form>
-</dialog>
-
-<style>
-  dialog {
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
-    border-radius: 0.75rem;
-    padding: 1.25rem;
-    background: light-dark(#fff, #1e1e1e);
-    color: inherit;
-    width: min(24rem, 90vw);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
-  }
-
-  dialog::backdrop {
-    background: rgba(0, 0, 0, 0.4);
-  }
-
-  button.primary:hover:not(:disabled) {
-    filter: brightness(1.08);
-  }
-
-  .actions button:not(.primary):hover {
-    filter: brightness(0.95);
-  }
-
-  h2 {
-    margin: 0 0 1rem;
-    font-size: 1.1rem;
-  }
-
-  form {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .field {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-    border: none;
-    padding: 0;
-    margin: 0;
-  }
-
-  .field > span,
-  .field legend {
-    font-size: 0.85rem;
-    font-weight: 600;
-    padding: 0;
-  }
-
-  input[type='text'],
-  select {
-    font: inherit;
-    padding: 0.4rem 0.5rem;
-    border-radius: 0.5rem;
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
-    background: light-dark(#fff, #262626);
-    color: inherit;
-  }
-
-  .light-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-    max-height: 10rem;
-    overflow-y: auto;
-    padding: 0.5rem;
-    border-radius: 0.5rem;
-    background: light-dark(#f7f7f7, #262626);
-  }
-
-  .light-option {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.9rem;
-  }
-
-  .hint {
-    font-size: 0.8rem;
-    color: light-dark(#666, #aaa);
-    margin: 0;
-  }
-
-  .error {
-    font-size: 0.85rem;
-    color: light-dark(#a3392c, #f0958a);
-    margin: 0;
-  }
-
-  .actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-  }
-
-  button {
-    font: inherit;
-    padding: 0.4rem 0.9rem;
-    border-radius: 999px;
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
-    background: light-dark(#eee, #333);
-    color: inherit;
-    cursor: pointer;
-  }
-
-  button.primary {
-    background: light-dark(#1c7a2e, #1f3d24);
-    color: light-dark(#fff, #7fe396);
-    border-color: transparent;
-  }
-
-  button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-</style>
+</FormDialog>

--- a/frontend/src/FormDialog.svelte
+++ b/frontend/src/FormDialog.svelte
@@ -1,0 +1,53 @@
+<script>
+  import { onMount } from 'svelte'
+
+  // Shared <dialog> mechanism for CreateSceneForm and AddFavoriteForm:
+  // opens itself on mount, and closes on a genuine backdrop click. The
+  // caller owns the dialog element (bind:dialogEl) so its own submit/cancel
+  // handlers can call dialogEl.close() directly, same as before this was
+  // extracted.
+  let { onClose, dialogEl = $bindable(null), children } = $props()
+
+  onMount(() => {
+    dialogEl?.showModal()
+  })
+
+  function handleBackdropClick(event) {
+    // Any click that doesn't land on a child element (backdrop AND the
+    // dialog's own padding around the form) reports target === dialog — so
+    // that check alone can't tell a real backdrop click from one that
+    // landed in the card's padding (visually still inside the card).
+    // Compare coordinates against the dialog's own rendered box instead
+    // (its border box, which includes the padding): only a click outside
+    // that box is a real click on the backdrop.
+    const rect = dialogEl.getBoundingClientRect()
+    const outside =
+      event.clientX < rect.left ||
+      event.clientX > rect.right ||
+      event.clientY < rect.top ||
+      event.clientY > rect.bottom
+    if (outside) {
+      dialogEl.close()
+    }
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} onclick={handleBackdropClick}>
+  {@render children()}
+</dialog>
+
+<style>
+  dialog {
+    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+    background: light-dark(#fff, #1e1e1e);
+    color: inherit;
+    width: min(24rem, 90vw);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  }
+
+  dialog::backdrop {
+    background: rgba(0, 0, 0, 0.4);
+  }
+</style>

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -21,3 +21,112 @@ main {
   margin: 0 auto;
   padding: 2rem;
 }
+
+/* Shared styling for the <form> inside FormDialog.svelte-wrapped dialogs
+   (CreateSceneForm, AddFavoriteForm) — kept global rather than duplicated
+   per-component since it's identical across both. */
+.dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dialog-form h2 {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+}
+
+.dialog-form .field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.dialog-form .field > span,
+.dialog-form .field legend {
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0;
+}
+
+.dialog-form input[type='text'],
+.dialog-form select {
+  font: inherit;
+  padding: 0.4rem 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+  background: light-dark(#fff, #262626);
+  color: inherit;
+}
+
+.dialog-form .option-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-height: 10rem;
+  overflow-y: auto;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  background: light-dark(#f7f7f7, #262626);
+}
+
+.dialog-form .option-list.tall {
+  max-height: 14rem;
+}
+
+.dialog-form .option-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.dialog-form .hint {
+  font-size: 0.8rem;
+  color: light-dark(#666, #aaa);
+  margin: 0;
+}
+
+.dialog-form .error {
+  font-size: 0.85rem;
+  color: light-dark(#a3392c, #f0958a);
+  margin: 0;
+}
+
+.dialog-form .actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.dialog-form button {
+  font: inherit;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+  background: light-dark(#eee, #333);
+  color: inherit;
+  cursor: pointer;
+}
+
+.dialog-form button.primary {
+  background: light-dark(#1c7a2e, #1f3d24);
+  color: light-dark(#fff, #7fe396);
+  border-color: transparent;
+}
+
+.dialog-form button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dialog-form button.primary:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+
+.dialog-form .actions button:not(.primary):hover {
+  filter: brightness(0.95);
+}


### PR DESCRIPTION
## Summary
Follow-up to #60's code review findings:
- **Race condition fix**: `addFavorites`/`removeFavorite` in App.svelte each computed the new list from `favoriteSceneIds` synchronously, so overlapping calls (e.g. two remove clicks on different Favorites cards, or an add racing a remove) could silently clobber each other — whichever PUT resolved last would win, both locally and in the persisted config.yaml. Now serialized through a single promise chain so each mutation reads the list only after the previous one has fully applied.
- **Dedupe dialog code**: `CreateSceneForm` and `AddFavoriteForm` had byte-for-byte duplicate `<dialog>` mechanics (backdrop-click coordinate math, open-on-mount) and ~80 lines of identical form/button/field CSS. Extracted the mechanics into a new `FormDialog.svelte` wrapper and moved the shared CSS into `.dialog-form` classes in `app.css`.

## Test plan
- [x] Backend: `pytest` — 64 passed (unchanged, this PR is frontend-only)
- [x] Frontend: `npm run build` succeeds
- [x] Manually verified in browser: dialog styling/behavior unchanged after the refactor; added two scenes to Favorites, rapidly clicked remove on both, reloaded — both correctly removed and persisted (no stale-snapshot clobber)