### PR TITLE
Add per-bulb color and color-temperature control

### DIFF
--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -70,7 +70,7 @@ class Zone(BaseModel):
     light_ids: list[str] = []
 
 
-# Standard Hue mired range (154 mired/~6500K "coolest" to 500 mired/2000K
+# Standard Hue mired range (153 mired/~6500K "coolest" to 500 mired/2000K
 # "warmest"), confirmed against this app's bulbs (see docs/hue-bridge-catalog.md).
 # Used both to render a 0-100 color_temp_pct for the UI and to convert a
 # slider position back to mired on write.
@@ -121,7 +121,11 @@ def _hex_to_xy(hex_color: str) -> tuple[float, float]:
 
     total = X + Y + Z
     if total <= 0:
-        return (0.0, 0.0)
+        # Black has no hue — (0, 0) isn't on the valid xy locus (y=0 is
+        # physically meaningless) and produces undefined bridge behavior.
+        # Fall back to the D65 white point instead of sending a degenerate
+        # coordinate.
+        return (0.3127, 0.3290)
     return (X / total, Y / total)
 
 
@@ -196,6 +200,18 @@ def _light_color(state: dict) -> Optional[str]:
     return None
 
 
+def _light_color_temp_pct(state: dict) -> Optional[int]:
+    try:
+        if "ct" in state:
+            return _mired_to_ct_pct(state["ct"])
+    except Exception:
+        # Same reasoning as _light_color: a malformed ct value on one bulb
+        # shouldn't take down the whole /api/lights response.
+        logger.warning("Could not compute color_temp_pct for light state %r", state, exc_info=True)
+        return None
+    return None
+
+
 def _bri_to_pct(bri: int) -> int:
     return round(bri / 254 * 100)
 
@@ -218,7 +234,7 @@ def _to_light(light_id: str, raw: dict) -> Light:
         on=state.get("on", False),
         brightness_pct=_bri_to_pct(state.get("bri", 0)),
         color=_light_color(state),
-        color_temp_pct=_mired_to_ct_pct(state["ct"]) if "ct" in state else None,
+        color_temp_pct=_light_color_temp_pct(state),
         supports_color=supports_color,
         supports_color_temp=supports_color_temp,
         reachable=state.get("reachable", False),

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -32,6 +32,16 @@ class Light(BaseModel):
     on: bool
     brightness_pct: int
     color: Optional[str] = None
+    # 0-100, 0=warmest/2000K, 100=coolest/6500K. Present only when the
+    # bulb's last-reported state included a `ct` value — not gated on
+    # supports_color_temp, since a full-color bulb can also report ct
+    # (whichever mode it's currently in).
+    color_temp_pct: Optional[int] = None
+    # Derived from the bridge's `type` string (see _light_capabilities) so
+    # the frontend can hide color/CT controls on bulbs that don't support
+    # them rather than offering a control that will just 502 on write.
+    supports_color: bool = False
+    supports_color_temp: bool = False
     reachable: bool
 
 
@@ -60,8 +70,59 @@ class Zone(BaseModel):
     light_ids: list[str] = []
 
 
+# Standard Hue mired range (154 mired/~6500K "coolest" to 500 mired/2000K
+# "warmest"), confirmed against this app's bulbs (see docs/hue-bridge-catalog.md).
+# Used both to render a 0-100 color_temp_pct for the UI and to convert a
+# slider position back to mired on write.
+MIN_MIRED = 153
+MAX_MIRED = 500
+
+
 def _to_hex(r: float, g: float, b: float) -> str:
     return "#{:02x}{:02x}{:02x}".format(round(r * 255), round(g * 255), round(b * 255))
+
+
+def _mired_to_ct_pct(mired: int) -> int:
+    mired = max(MIN_MIRED, min(MAX_MIRED, mired))
+    return round((MAX_MIRED - mired) / (MAX_MIRED - MIN_MIRED) * 100)
+
+
+def _ct_pct_to_mired(pct: int) -> int:
+    return round(MAX_MIRED - (pct / 100) * (MAX_MIRED - MIN_MIRED))
+
+
+def _light_capabilities(light_type: str) -> tuple[bool, bool]:
+    """(supports_color, supports_color_temp), derived from the bridge's `type` string.
+
+    Confirmed against this app's bulbs (docs/hue-bridge-catalog.md):
+    "Dimmable light" (bri/on only), "Extended color light" (full xy/hs/ct),
+    "Color temperature light" (ct only). "Color light" is an older-generation
+    xy/hs-only type (no ct) that exists in Hue's lineup but not in this
+    app's current bulbs.
+    """
+    supports_color = light_type in ("Color light", "Extended color light")
+    supports_color_temp = light_type in ("Color temperature light", "Extended color light")
+    return supports_color, supports_color_temp
+
+
+def _hex_to_xy(hex_color: str) -> tuple[float, float]:
+    """sRGB hex -> Philips' documented xyY, inverse of _xy_to_rgb_hex's matrix."""
+    hex_color = hex_color.lstrip("#")
+    r, g, b = (int(hex_color[i : i + 2], 16) / 255 for i in (0, 2, 4))
+
+    def degamma(c: float) -> float:
+        return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+    r, g, b = degamma(r), degamma(g), degamma(b)
+
+    X = r * 0.664511 + g * 0.154324 + b * 0.162028
+    Y = r * 0.283881 + g * 0.668433 + b * 0.047685
+    Z = r * 0.000088 + g * 0.072310 + b * 0.986039
+
+    total = X + Y + Z
+    if total <= 0:
+        return (0.0, 0.0)
+    return (X / total, Y / total)
 
 
 def _xy_to_rgb_hex(x: float, y: float) -> str:
@@ -150,12 +211,16 @@ def _pct_to_bri(pct: int) -> int:
 
 def _to_light(light_id: str, raw: dict) -> Light:
     state = raw.get("state", {})
+    supports_color, supports_color_temp = _light_capabilities(raw.get("type", ""))
     return Light(
         id=light_id,
         name=raw.get("name", f"Light {light_id}"),
         on=state.get("on", False),
         brightness_pct=_bri_to_pct(state.get("bri", 0)),
         color=_light_color(state),
+        color_temp_pct=_mired_to_ct_pct(state["ct"]) if "ct" in state else None,
+        supports_color=supports_color,
+        supports_color_temp=supports_color_temp,
         reachable=state.get("reachable", False),
     )
 
@@ -464,13 +529,23 @@ async def create_scene(
 
 
 async def set_light_state(
-    config: BridgeConfig, light_id: str, *, on: Optional[bool] = None, brightness_pct: Optional[int] = None
+    config: BridgeConfig,
+    light_id: str,
+    *,
+    on: Optional[bool] = None,
+    brightness_pct: Optional[int] = None,
+    color: Optional[str] = None,
+    color_temp_pct: Optional[int] = None,
 ) -> None:
     body = {}
     if on is not None:
         body["on"] = on
     if brightness_pct is not None:
         body["bri"] = _pct_to_bri(brightness_pct)
+    if color is not None:
+        body["xy"] = list(_hex_to_xy(color))
+    if color_temp_pct is not None:
+        body["ct"] = _ct_pct_to_mired(color_temp_pct)
     await _bridge_request(config, f"lights/{light_id}/state", method="PUT", json_body=body)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -68,14 +68,28 @@ class LightStateUpdate(BaseModel):
     # 0 isn't a settable target (that's what on: false is for) — matches
     # _pct_to_bri's floor of 1.
     brightness_pct: Optional[int] = Field(default=None, ge=1, le=100)
+    # sRGB hex, e.g. "#ff8800" — converted to the bridge's xy color space in
+    # set_light_state. Only meaningful for a light with supports_color=true;
+    # the bridge itself rejects xy on a color-temp-only or dimmable bulb, so
+    # that rejection is left to surface as a normal 502 rather than
+    # duplicated here.
+    color: Optional[str] = Field(default=None, pattern=r"^#[0-9a-fA-F]{6}$")
+    color_temp_pct: Optional[int] = Field(default=None, ge=0, le=100)
 
 
 @app.put("/api/lights/{light_id}/state")
 async def update_light_state(light_id: str, update: LightStateUpdate):
-    if update.on is None and update.brightness_pct is None:
-        raise HTTPException(status_code=400, detail="must set on and/or brightness_pct")
+    if update.on is None and update.brightness_pct is None and update.color is None and update.color_temp_pct is None:
+        raise HTTPException(status_code=400, detail="must set on, brightness_pct, color, and/or color_temp_pct")
     config = load_config()
-    await set_light_state(config, light_id, on=update.on, brightness_pct=update.brightness_pct)
+    await set_light_state(
+        config,
+        light_id,
+        on=update.on,
+        brightness_pct=update.brightness_pct,
+        color=update.color,
+        color_temp_pct=update.color_temp_pct,
+    )
     return {"status": "ok"}
 
 

--- a/backend/tests/test_existing_routes.py
+++ b/backend/tests/test_existing_routes.py
@@ -76,6 +76,34 @@ async def test_list_lights_exposes_capabilities_per_type(client):
 
 
 @respx.mock
+async def test_list_lights_malformed_ct_does_not_500_whole_response(client):
+    respx.get(f"{BRIDGE_URL}/lights").mock(
+        return_value=Response(
+            200,
+            json={
+                "1": {
+                    "name": "Malformed ct",
+                    "type": "Color temperature light",
+                    "state": {"on": True, "bri": 254, "ct": None, "reachable": True},
+                },
+                "2": {
+                    "name": "Fine",
+                    "type": "Color temperature light",
+                    "state": {"on": True, "bri": 254, "ct": 300, "colormode": "ct", "reachable": True},
+                },
+            },
+        )
+    )
+
+    resp = await client.get("/api/lights")
+
+    assert resp.status_code == 200
+    by_id = {light["id"]: light for light in resp.json()}
+    assert by_id["1"]["color_temp_pct"] is None
+    assert by_id["2"]["color_temp_pct"] is not None
+
+
+@respx.mock
 async def test_list_scenes(client):
     respx.get(f"{BRIDGE_URL}/scenes").mock(
         return_value=Response(

--- a/backend/tests/test_existing_routes.py
+++ b/backend/tests/test_existing_routes.py
@@ -31,9 +31,48 @@ async def test_list_lights(client):
             "on": True,
             "brightness_pct": 100,
             "color": None,
+            "color_temp_pct": None,
+            "supports_color": False,
+            "supports_color_temp": False,
             "reachable": True,
         }
     ]
+
+
+@respx.mock
+async def test_list_lights_exposes_capabilities_per_type(client):
+    respx.get(f"{BRIDGE_URL}/lights").mock(
+        return_value=Response(
+            200,
+            json={
+                "1": {
+                    "name": "Dimmable",
+                    "type": "Dimmable light",
+                    "state": {"on": True, "bri": 254, "reachable": True},
+                },
+                "2": {
+                    "name": "CT only",
+                    "type": "Color temperature light",
+                    "state": {"on": True, "bri": 254, "ct": 300, "colormode": "ct", "reachable": True},
+                },
+                "3": {
+                    "name": "Full color",
+                    "type": "Extended color light",
+                    "state": {"on": True, "bri": 254, "ct": 200, "colormode": "ct", "reachable": True},
+                },
+            },
+        )
+    )
+
+    resp = await client.get("/api/lights")
+
+    assert resp.status_code == 200
+    by_id = {light["id"]: light for light in resp.json()}
+    assert (by_id["1"]["supports_color"], by_id["1"]["supports_color_temp"]) == (False, False)
+    assert (by_id["2"]["supports_color"], by_id["2"]["supports_color_temp"]) == (False, True)
+    assert (by_id["3"]["supports_color"], by_id["3"]["supports_color_temp"]) == (True, True)
+    assert by_id["2"]["color_temp_pct"] is not None
+    assert by_id["1"]["color_temp_pct"] is None
 
 
 @respx.mock

--- a/backend/tests/test_light_routes.py
+++ b/backend/tests/test_light_routes.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 import respx
 from httpx import Response
 
@@ -93,3 +94,37 @@ async def test_set_light_state_bridge_not_configured_returns_503(client, monkeyp
     resp = await client.put("/api/lights/1/state", json={"on": True})
 
     assert resp.status_code == 503
+
+
+@respx.mock
+async def test_set_light_color(client):
+    state_route = respx.put(f"{BRIDGE_URL}/lights/1/state").mock(
+        return_value=Response(200, json=[{"success": {"/lights/1/state/xy": [0.5, 0.4]}}])
+    )
+
+    resp = await client.put("/api/lights/1/state", json={"color": "#ff0000"})
+
+    assert resp.status_code == 200
+    body = json.loads(state_route.calls.last.request.content)
+    assert list(body.keys()) == ["xy"]
+    x, y = body["xy"]
+    assert x == pytest.approx(0.7006, abs=1e-3)
+    assert y == pytest.approx(0.2993, abs=1e-3)
+
+
+@respx.mock
+async def test_set_light_color_temp(client):
+    state_route = respx.put(f"{BRIDGE_URL}/lights/1/state").mock(
+        return_value=Response(200, json=[{"success": {"/lights/1/state/ct": 326}}])
+    )
+
+    resp = await client.put("/api/lights/1/state", json={"color_temp_pct": 50})
+
+    assert resp.status_code == 200
+    assert json.loads(state_route.calls.last.request.content) == {"ct": 326}
+
+
+async def test_set_light_state_invalid_color_is_422(client):
+    resp = await client.put("/api/lights/1/state", json={"color": "not-a-color"})
+
+    assert resp.status_code == 422

--- a/backend/tests/test_light_routes.py
+++ b/backend/tests/test_light_routes.py
@@ -124,6 +124,23 @@ async def test_set_light_color_temp(client):
     assert json.loads(state_route.calls.last.request.content) == {"ct": 326}
 
 
+@respx.mock
+async def test_set_light_color_black_sends_white_point_not_degenerate_xy(client):
+    # #000000 has no hue — _hex_to_xy must not send an off-locus (0, 0) that
+    # produces undefined bridge behavior.
+    state_route = respx.put(f"{BRIDGE_URL}/lights/1/state").mock(
+        return_value=Response(200, json=[{"success": {"/lights/1/state/xy": [0.3127, 0.329]}}])
+    )
+
+    resp = await client.put("/api/lights/1/state", json={"color": "#000000"})
+
+    assert resp.status_code == 200
+    body = json.loads(state_route.calls.last.request.content)
+    x, y = body["xy"]
+    assert x == pytest.approx(0.3127, abs=1e-4)
+    assert y == pytest.approx(0.3290, abs=1e-4)
+
+
 async def test_set_light_state_invalid_color_is_422(client):
     resp = await client.put("/api/lights/1/state", json={"color": "not-a-color"})
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -268,6 +268,50 @@
     }
   }
 
+  // Same optimistic-update-with-revert-if-still-latest pattern as
+  // setLightBrightness, tracked separately so an in-flight color request
+  // isn't stomped by a color-temp request racing it (or vice versa).
+  const latestColorRequest = new Map()
+  const latestColorTempRequest = new Map()
+
+  async function setLightColor(lightId, hex) {
+    const light = lights.find((l) => l.id === lightId)
+    if (!light) return
+    const prev = { on: light.on, color: light.color }
+    const token = Symbol()
+    latestColorRequest.set(lightId, token)
+    light.color = hex
+    light.on = true
+    light.toggleError = null
+    try {
+      await putJson(`/api/lights/${lightId}/state`, { color: hex, on: true })
+    } catch (err) {
+      if (latestColorRequest.get(lightId) === token) {
+        Object.assign(light, prev)
+        light.toggleError = err.message
+      }
+    }
+  }
+
+  async function setLightColorTemp(lightId, pct) {
+    const light = lights.find((l) => l.id === lightId)
+    if (!light) return
+    const prev = { on: light.on, color_temp_pct: light.color_temp_pct }
+    const token = Symbol()
+    latestColorTempRequest.set(lightId, token)
+    light.color_temp_pct = pct
+    light.on = true
+    light.toggleError = null
+    try {
+      await putJson(`/api/lights/${lightId}/state`, { color_temp_pct: pct, on: true })
+    } catch (err) {
+      if (latestColorTempRequest.get(lightId) === token) {
+        Object.assign(light, prev)
+        light.toggleError = err.message
+      }
+    }
+  }
+
   // Which zone's "New Scene" dialog is open, if any (issue #30 — one button
   // per zone rather than a single global one).
   let createFormZone = $state(null)
@@ -459,7 +503,13 @@
         {:else}
           <div class="bulbs-list">
             {#each lights as light (light.id)}
-              <LightCard {light} onToggle={toggleLight} onBrightnessChange={setLightBrightness} />
+              <LightCard
+                {light}
+                onToggle={toggleLight}
+                onBrightnessChange={setLightBrightness}
+                onColorChange={setLightColor}
+                onColorTempChange={setLightColorTemp}
+              />
             {/each}
           </div>
         {/if}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -304,6 +304,12 @@
     light.toggleError = null
     try {
       await putJson(`/api/lights/${lightId}/state`, { color_temp_pct: pct, on: true })
+      // Unlike setLightBrightness/setLightColor, the optimistic update above
+      // only sets color_temp_pct — it can't also approximate the header
+      // swatch's `color` (rendered from whatever colormode the bulb reports),
+      // so that would otherwise sit stale until some other action happens to
+      // refresh `lights`. Refetch to pick up the bridge's recomputed color.
+      await refreshLights()
     } catch (err) {
       if (latestColorTempRequest.get(lightId) === token) {
         Object.assign(light, prev)

--- a/frontend/src/LightCard.svelte
+++ b/frontend/src/LightCard.svelte
@@ -1,7 +1,7 @@
 <script>
   import BrightnessSlider from './BrightnessSlider.svelte'
 
-  let { light, onToggle, onBrightnessChange } = $props()
+  let { light, onToggle, onBrightnessChange, onColorChange, onColorTempChange } = $props()
 
   // Serializes toggle clicks for this card: while a PUT is in flight the
   // button is disabled, so a fast double-click can't fire a second request
@@ -19,17 +19,20 @@
     }
   }
 
-  // The swatch and brightness slider are their own interactive/decorative
-  // regions, not part of the toggle target — a click that lands in either
-  // (checked via closest, since the slider's range input is what's actually
-  // clicked) shouldn't also toggle the light.
+  // The swatch, brightness slider, color picker, and color-temp slider are
+  // their own interactive/decorative regions, not part of the toggle target
+  // — a click that lands in any of them (checked via closest, since the
+  // actual input elements are what's clicked) shouldn't also toggle the
+  // light.
+  const CONTROL_SELECTOR = '.swatch, .slider-wrap, .color-wrap, .ct-wrap'
+
   function handleCardClick(event) {
-    if (event.target.closest('.swatch, .slider-wrap')) return
+    if (event.target.closest(CONTROL_SELECTOR)) return
     handleToggle()
   }
 
   function handleKeydown(event) {
-    if (event.target.closest('.swatch, .slider-wrap')) return
+    if (event.target.closest(CONTROL_SELECTOR)) return
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       handleToggle()
@@ -74,6 +77,31 @@
       onChange={(pct) => onBrightnessChange(light.id, pct)}
     />
   </div>
+
+  {#if light.supports_color}
+    <div class="color-wrap">
+      <input
+        type="color"
+        class="color-input"
+        value={light.color ?? '#ffe9b3'}
+        aria-label="{light.name} color"
+        onchange={(event) => onColorChange(light.id, event.target.value)}
+      />
+    </div>
+  {/if}
+
+  {#if light.supports_color_temp}
+    <div class="ct-wrap">
+      <BrightnessSlider
+        value={light.color_temp_pct ?? 50}
+        min={0}
+        max={100}
+        showValue={false}
+        label="{light.name} color temperature"
+        onChange={(pct) => onColorTempChange(light.id, pct)}
+      />
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -124,8 +152,24 @@
     transition: box-shadow 0.2s ease, background-color 0.2s ease;
   }
 
-  .slider-wrap {
+  .slider-wrap,
+  .color-wrap,
+  .ct-wrap {
     cursor: default;
+  }
+
+  .color-input {
+    width: 100%;
+    height: 1.75rem;
+    border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.25));
+    border-radius: 0.4rem;
+    padding: 0;
+    background: none;
+    cursor: pointer;
+  }
+
+  .ct-wrap :global(input[type='range']) {
+    background: linear-gradient(to right, #ffb347, #cfe8ff);
   }
 
   .name {


### PR DESCRIPTION
## Summary
- Extends `LightStateUpdate`/`set_light_state` to accept an sRGB hex `color` (converted server-side to the bridge's xy color space) and a `color_temp_pct` (0-100, converted to mired).
- `Light` now exposes `supports_color`/`supports_color_temp`, derived from the bridge's per-light `type` string (dimmable-only, ct-only, or full xy/hs/ct), plus `color_temp_pct` for the bulb's current ct position.
- `LightCard` shows a native color picker for bulbs with `supports_color` and a warm↔cool gradient slider for bulbs with `supports_color_temp`, following the same optimistic-update/revert pattern as brightness.

Closes #40.

## Test plan
- [x] Backend: `pytest` (68 passed), including new color/CT write tests and a capability-exposure test against `Dimmable light` / `Color temperature light` / `Extended color light` type strings.
- [x] Manually verified against the real bridge: `/api/lights` correctly flags real color/CT-capable bulbs (Kitchen Color, Corner Color 1-3, Color Reading Lamp, Color Floor Lamp 1-2 as full xy+ct; Bedside Table Lamp as ct-only; Chandeliers/Kitchen Dome as neither).
- [x] Manually verified in the browser: color picker and CT slider render only on capable bulbs; confirmed a live PUT round-trips through to the real bulb and back (color clamped to the bridge's gamut as expected).
- [x] Restored the two bulbs touched during manual testing to their original color/CT values afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)