### PR TITLE
Add warm/cool color palettes with a header toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,16 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hue Light Control</title>
+    <script>
+      // Set data-palette before first paint so a persisted "cool" choice
+      // doesn't flash the default warm palette on reload — App.svelte's
+      // $effect that normally owns this only runs after mount.
+      try {
+        if (localStorage.getItem('palette') === 'cool') {
+          document.documentElement.dataset.palette = 'cool'
+        }
+      } catch {}
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -57,6 +57,29 @@
     }
   })
 
+  // Warm/cool color palette (issue #20), persisted the same way as
+  // bulbsCollapsed. Applied via a data-palette attribute on <html> rather
+  // than scoped to this component, since app.css's palette tokens (and the
+  // global .dialog-form rules) need it to cascade to the whole page,
+  // including dialogs mounted outside <main>.
+  function readPalette() {
+    try {
+      return localStorage.getItem('palette') === 'cool' ? 'cool' : 'warm'
+    } catch {
+      return 'warm'
+    }
+  }
+
+  let palette = $state(readPalette())
+  $effect(() => {
+    document.documentElement.dataset.palette = palette
+    try {
+      localStorage.setItem('palette', palette)
+    } catch {
+      // Ignore — persistence is a nice-to-have, not required for the toggle to work.
+    }
+  })
+
   async function loadLights() {
     lightsLoading = true
     lightsError = null
@@ -482,8 +505,20 @@
 </script>
 
 <main>
-  <h1>Hue Light Control</h1>
-  <p class="subtitle">Bulbs and scenes on your local Hue bridge</p>
+  <div class="page-header">
+    <div>
+      <h1>Hue Light Control</h1>
+      <p class="subtitle">Bulbs and scenes on your local Hue bridge</p>
+    </div>
+    <div class="palette-toggle" role="group" aria-label="Color palette">
+      <button type="button" class:active={palette === 'warm'} onclick={() => (palette = 'warm')}>
+        Warm
+      </button>
+      <button type="button" class:active={palette === 'cool'} onclick={() => (palette = 'cool')}>
+        Cool
+      </button>
+    </div>
+  </div>
 
   <div class="layout">
     <aside class="bulbs-panel" class:collapsed={bulbsCollapsed}>
@@ -617,6 +652,14 @@
 </main>
 
 <style>
+  .page-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
   h1 {
     margin: 0;
     font-size: 1.75rem;
@@ -625,8 +668,39 @@
 
   .subtitle {
     margin: 0.3rem 0 0;
-    color: light-dark(#666, #999);
+    color: var(--text-muted);
     font-size: 0.95rem;
+  }
+
+  .palette-toggle {
+    display: flex;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface-alt);
+    padding: 0.2rem;
+    flex-shrink: 0;
+  }
+
+  .palette-toggle button {
+    font: inherit;
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background-color 0.15s ease, color 0.15s ease;
+  }
+
+  .palette-toggle button.active {
+    background: var(--accent);
+    color: var(--accent-text);
+  }
+
+  .palette-toggle button:not(.active):hover {
+    color: var(--text);
   }
 
   .layout {
@@ -684,8 +758,8 @@
     height: 1.75rem;
     padding: 0;
     border-radius: 999px;
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
-    background: light-dark(#eee, #333);
+    border: 1px solid var(--border);
+    background: var(--surface-alt);
     color: inherit;
     cursor: pointer;
     transition: filter 0.15s ease;
@@ -723,8 +797,8 @@
     font-weight: 600;
     padding: 0.4rem 0.9rem;
     border-radius: 999px;
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
-    background: light-dark(#eee, #333);
+    border: 1px solid var(--border);
+    background: var(--surface-alt);
     color: inherit;
     cursor: pointer;
     transition: filter 0.15s ease;
@@ -741,9 +815,9 @@
   }
 
   .zone-group {
-    border: 1px solid light-dark(#dedede, #333);
+    border: 1px solid var(--border);
     border-radius: 1rem;
-    background: light-dark(#ebebe9, #1a1a1a);
+    background: var(--surface-alt);
     padding: 1.25rem;
   }
 
@@ -762,7 +836,7 @@
     margin: 0;
     font-size: 0.95rem;
     font-weight: 600;
-    color: light-dark(#555, #aaa);
+    color: var(--text-muted);
     flex-shrink: 0;
   }
 
@@ -774,11 +848,11 @@
 
   .hint {
     font-size: 0.85rem;
-    color: light-dark(#666, #999);
+    color: var(--text-muted);
     margin: 0;
   }
 
   .error {
-    color: light-dark(#a3392c, #f0958a);
+    color: var(--error-text);
   }
 </style>

--- a/frontend/src/BrightnessSlider.svelte
+++ b/frontend/src/BrightnessSlider.svelte
@@ -35,7 +35,7 @@
     -webkit-appearance: none;
     height: 0.4rem;
     border-radius: 999px;
-    background: light-dark(#eee, #333);
+    background: var(--surface-alt);
     outline: none;
   }
 
@@ -49,7 +49,7 @@
     width: 0.9rem;
     height: 0.9rem;
     border-radius: 50%;
-    background: light-dark(#333, #ddd);
+    background: var(--accent);
     cursor: pointer;
   }
 
@@ -58,19 +58,19 @@
     height: 0.9rem;
     border: none;
     border-radius: 50%;
-    background: light-dark(#333, #ddd);
+    background: var(--accent);
     cursor: pointer;
   }
 
   input[type='range']::-moz-range-progress {
-    background: light-dark(#333, #ddd);
+    background: var(--accent);
     border-radius: 999px;
     height: 0.4rem;
   }
 
   .brightness-label {
     font-size: 0.75rem;
-    color: light-dark(#666, #aaa);
+    color: var(--text-muted);
     width: 2.5rem;
     text-align: right;
   }

--- a/frontend/src/FormDialog.svelte
+++ b/frontend/src/FormDialog.svelte
@@ -38,10 +38,10 @@
 
 <style>
   dialog {
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    border: 1px solid var(--border);
     border-radius: 0.75rem;
     padding: 1.25rem;
-    background: light-dark(#fff, #1e1e1e);
+    background: var(--surface);
     color: inherit;
     width: min(24rem, 90vw);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);

--- a/frontend/src/LightCard.svelte
+++ b/frontend/src/LightCard.svelte
@@ -106,24 +106,24 @@
 
 <style>
   .card {
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    border: 1px solid var(--border);
     border-radius: 0.75rem;
     padding: 1rem;
     display: flex;
     flex-direction: column;
     gap: 0.6rem;
-    background: light-dark(#fff, #1e1e1e);
-    box-shadow: 0 1px 2px light-dark(rgba(0, 0, 0, 0.04), rgba(0, 0, 0, 0.2));
-    transition: box-shadow 0.15s ease;
+    background: var(--surface);
+    box-shadow: 0 1px 2px var(--shadow-color);
+    transition: box-shadow 0.15s ease, background-color 0.2s ease, border-color 0.2s ease;
     cursor: pointer;
   }
 
   .card:hover {
-    box-shadow: 0 2px 8px light-dark(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.3));
+    box-shadow: 0 2px 8px var(--shadow-color);
   }
 
   .card:focus-visible {
-    outline: 2px solid light-dark(#1c7a2e, #7fe396);
+    outline: 2px solid var(--accent);
     outline-offset: 2px;
   }
 
@@ -145,8 +145,8 @@
     width: 1.25rem;
     height: 1.25rem;
     border-radius: 50%;
-    border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.25));
-    background: light-dark(#e2e2e2, #2a2a2a);
+    border: 1px solid var(--border);
+    background: var(--surface-alt);
     flex-shrink: 0;
     cursor: default;
     transition: box-shadow 0.2s ease, background-color 0.2s ease;
@@ -161,7 +161,7 @@
   .color-input {
     width: 100%;
     height: 1.75rem;
-    border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.25));
+    border: 1px solid var(--border);
     border-radius: 0.4rem;
     padding: 0;
     background: none;
@@ -185,15 +185,15 @@
     font-size: 0.75rem;
     padding: 0.15rem 0.5rem;
     border-radius: 999px;
-    background: light-dark(#eee, #333);
-    color: light-dark(#555, #ccc);
+    background: var(--surface-alt);
+    color: var(--text-muted);
     width: fit-content;
     transition: background-color 0.15s ease, color 0.15s ease;
   }
 
   .unreachable-badge,
   .error-badge {
-    background: light-dark(#fbe3e0, #3d211f);
-    color: light-dark(#a3392c, #f0958a);
+    background: var(--error-bg);
+    color: var(--error-text);
   }
 </style>

--- a/frontend/src/SceneCard.svelte
+++ b/frontend/src/SceneCard.svelte
@@ -167,18 +167,18 @@
 
 <style>
   .card {
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
+    border: 1px solid var(--border);
     border-radius: 0.75rem;
     display: flex;
     flex-direction: column;
-    background: light-dark(#fff, #1e1e1e);
+    background: var(--surface);
     width: 100%;
-    box-shadow: 0 1px 2px light-dark(rgba(0, 0, 0, 0.04), rgba(0, 0, 0, 0.2));
-    transition: box-shadow 0.15s ease;
+    box-shadow: 0 1px 2px var(--shadow-color);
+    transition: box-shadow 0.15s ease, background-color 0.2s ease, border-color 0.2s ease;
   }
 
   .card:not(.inactive):hover {
-    box-shadow: 0 2px 8px light-dark(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.3));
+    box-shadow: 0 2px 8px var(--shadow-color);
   }
 
   .card.inactive {
@@ -210,7 +210,7 @@
   }
 
   .activate:focus-visible {
-    outline: 2px solid light-dark(#1c7a2e, #7fe396);
+    outline: 2px solid var(--accent);
     outline-offset: -2px;
   }
 
@@ -242,8 +242,8 @@
     width: 1.75rem;
     height: 1.75rem;
     border-radius: 50%;
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
-    background: light-dark(#f4f4f4, #2a2a2a);
+    border: 1px solid var(--border);
+    background: var(--surface-alt);
     font-size: 0.7rem;
     line-height: 1;
     display: flex;
@@ -255,7 +255,7 @@
 
   .remove-favorite:hover:not(:disabled) {
     filter: brightness(0.95);
-    color: light-dark(#a3392c, #f0958a);
+    color: var(--error-text);
   }
 
   .remove-favorite:disabled {
@@ -268,8 +268,8 @@
     width: 1.75rem;
     height: 1.75rem;
     border-radius: 50%;
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
-    background: light-dark(#f4f4f4, #2a2a2a);
+    border: 1px solid var(--border);
+    background: var(--surface-alt);
     font-size: 0.75rem;
     line-height: 1;
     display: flex;
@@ -289,8 +289,8 @@
   }
 
   .play-toggle.playing {
-    background: light-dark(#dff0e0, #1f3a26);
-    border-color: light-dark(#9fd6a8, #2f5a3b);
+    background: var(--accent-soft-bg);
+    border-color: var(--accent-soft-border);
   }
 
   .speed-row {
@@ -301,13 +301,13 @@
     font-size: 0.75rem;
     padding: 0.15rem 0.5rem;
     border-radius: 999px;
-    background: light-dark(#eee, #333);
-    color: light-dark(#555, #ccc);
+    background: var(--surface-alt);
+    color: var(--text-muted);
     width: fit-content;
   }
 
   .error-badge {
-    background: light-dark(#fbe3e0, #3d211f);
-    color: light-dark(#a3392c, #f0958a);
+    background: var(--error-bg);
+    color: var(--error-text);
   }
 </style>

--- a/frontend/src/ZoneBrightnessSlider.svelte
+++ b/frontend/src/ZoneBrightnessSlider.svelte
@@ -95,8 +95,8 @@
   }
 
   .error-badge {
-    background: light-dark(#fbe3e0, #3d211f);
-    color: light-dark(#a3392c, #f0958a);
+    background: var(--error-bg);
+    color: var(--error-text);
   }
 
   .zone-off-button {
@@ -105,8 +105,8 @@
     font-weight: 600;
     padding: 0.4rem 0.9rem;
     border-radius: 999px;
-    border: 1px solid light-dark(#d8d8d8, #3a3a3a);
-    background: light-dark(#eee, #333);
+    border: 1px solid var(--border);
+    background: var(--surface-alt);
     cursor: pointer;
     flex-shrink: 0;
   }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,6 +1,41 @@
 :root {
   color-scheme: light dark;
   font-family: -apple-system, system-ui, sans-serif;
+
+  /* Warm palette (default) — issue #20's two selectable themes, toggled by
+     setting data-palette on <html> (see App.svelte). Every color elsewhere
+     in the app should reference one of these tokens rather than hardcoding
+     light-dark() directly, so it repaints when the palette switches. */
+  --bg: light-dark(#faf6f1, #1c1712);
+  --surface: light-dark(#ffffff, #241d16);
+  --surface-alt: light-dark(#f5ede4, #2a2018);
+  --border: light-dark(#e0d3c2, #3d3020);
+  --text: light-dark(#2a2015, #f2e6d8);
+  --text-muted: light-dark(#8a7259, #b8a488);
+  --accent: light-dark(#c2650a, #e8952f);
+  --accent-text: light-dark(#fff8f0, #1c1712);
+  --accent-soft-bg: light-dark(#ffe9d5, #3d2a12);
+  --accent-soft-border: light-dark(#f0b876, #6b4a1e);
+  --shadow-color: light-dark(rgba(40, 25, 10, 0.1), rgba(0, 0, 0, 0.35));
+
+  /* Semantic — errors read as "error" regardless of palette, so these don't
+     vary between warm and cool. */
+  --error-bg: light-dark(#fbe3e0, #3d211f);
+  --error-text: light-dark(#a3392c, #f0958a);
+}
+
+[data-palette='cool'] {
+  --bg: light-dark(#f1f6f8, #10171c);
+  --surface: light-dark(#ffffff, #17212a);
+  --surface-alt: light-dark(#e8eef2, #1c2830);
+  --border: light-dark(#ccdae3, #2b3c47);
+  --text: light-dark(#16232b, #e4edf2);
+  --text-muted: light-dark(#5f7684, #93a8b3);
+  --accent: light-dark(#1f6fb2, #4fa3e0);
+  --accent-text: light-dark(#f5fbff, #0b1116);
+  --accent-soft-bg: light-dark(#dcedfa, #16283a);
+  --accent-soft-border: light-dark(#8ec3e8, #235279);
+  --shadow-color: light-dark(rgba(10, 30, 45, 0.1), rgba(0, 0, 0, 0.35));
 }
 
 *,
@@ -12,8 +47,9 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: light-dark(#f5f5f4, #161616);
-  color: light-dark(#1a1a1a, #ededed);
+  background: var(--bg);
+  color: var(--text);
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 main {
@@ -57,8 +93,8 @@ main {
   font: inherit;
   padding: 0.4rem 0.5rem;
   border-radius: 0.5rem;
-  border: 1px solid light-dark(#d8d8d8, #3a3a3a);
-  background: light-dark(#fff, #262626);
+  border: 1px solid var(--border);
+  background: var(--surface);
   color: inherit;
 }
 
@@ -70,7 +106,7 @@ main {
   overflow-y: auto;
   padding: 0.5rem;
   border-radius: 0.5rem;
-  background: light-dark(#f7f7f7, #262626);
+  background: var(--surface-alt);
 }
 
 .dialog-form .option-list.tall {
@@ -86,13 +122,13 @@ main {
 
 .dialog-form .hint {
   font-size: 0.8rem;
-  color: light-dark(#666, #aaa);
+  color: var(--text-muted);
   margin: 0;
 }
 
 .dialog-form .error {
   font-size: 0.85rem;
-  color: light-dark(#a3392c, #f0958a);
+  color: var(--error-text);
   margin: 0;
 }
 
@@ -106,15 +142,15 @@ main {
   font: inherit;
   padding: 0.4rem 0.9rem;
   border-radius: 999px;
-  border: 1px solid light-dark(#d8d8d8, #3a3a3a);
-  background: light-dark(#eee, #333);
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
   color: inherit;
   cursor: pointer;
 }
 
 .dialog-form button.primary {
-  background: light-dark(#1c7a2e, #1f3d24);
-  color: light-dark(#fff, #7fe396);
+  background: var(--accent);
+  color: var(--accent-text);
   border-color: transparent;
 }
 


### PR DESCRIPTION
## Summary
- Closes #20
- Introduces CSS custom properties (`--bg`, `--surface`, `--accent`, etc.) defined per palette in `app.css`, replacing hardcoded `light-dark()` colors across every component so all elements repaint on palette switch.
- Adds a Warm/Cool toggle in the page header; the choice is persisted to `localStorage` and applied via a `data-palette` attribute on `<html>`, set inline in `index.html` before hydration to avoid a flash of the wrong theme on reload.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified both palettes visually in Chrome against the real bridge (bulb cards, scene cards, zone sliders, dialogs, badges, focus states) in both warm and cool
- [x] Ran `/code-review`; addressed its one finding (FOUC on reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)