### PR TITLE
Frontend: full theme system, replacing warm/cool toggle

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import threading
 from pathlib import Path
 from typing import Optional
 
@@ -7,6 +8,18 @@ import yaml
 from pydantic import BaseModel
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.yaml"
+
+# Serializes add_custom_theme's check-then-write against itself — FastAPI's
+# sync routes run in a threadpool, so two concurrent imports could otherwise
+# both read config.yaml before either writes, both pass a duplicate-id
+# check done outside this lock, and the second write would silently clobber
+# the first (each import_theme caller still getting a 201) rather than one
+# of them getting the intended 409.
+_themes_lock = threading.Lock()
+
+
+class DuplicateThemeError(Exception):
+    pass
 
 
 class Theme(BaseModel):
@@ -68,9 +81,12 @@ def update_favorite_scene_ids(scene_ids: list[str]) -> None:
 
 
 def add_custom_theme(theme: Theme) -> None:
-    config = load_config()
-    config.custom_themes = [t for t in config.custom_themes if t.id != theme.id] + [theme]
-    _write_config(config)
+    with _themes_lock:
+        config = load_config()
+        if any(t.id == theme.id for t in config.custom_themes):
+            raise DuplicateThemeError(theme.id)
+        config.custom_themes = [*config.custom_themes, theme]
+        _write_config(config)
 
 
 def remove_custom_theme(theme_id: str) -> None:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,6 +9,17 @@ from pydantic import BaseModel
 CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.yaml"
 
 
+class Theme(BaseModel):
+    id: str
+    name: str
+    # Flat map of CSS custom-property name (e.g. "--bg") to value. Stored
+    # opaquely — the backend doesn't know or care which properties the
+    # frontend's stylesheet actually reads, so a theme can introduce new
+    # tokens (e.g. for a future LCARS/Wipeout theme, issues #43/#42) without
+    # backend changes.
+    tokens: dict[str, str]
+
+
 class BridgeConfig(BaseModel):
     bridge_ip: Optional[str] = None
     api_key: Optional[str] = None
@@ -16,6 +27,10 @@ class BridgeConfig(BaseModel):
     # data, so it lives alongside bridge_ip/api_key in the same local config
     # rather than requiring a separate store.
     favorite_scene_ids: list[str] = []
+    # User-imported themes (issue #21). The built-in "Default - Dark" /
+    # "Default - Light" themes ship as frontend code, not here — this only
+    # holds themes imported at runtime via POST /api/themes.
+    custom_themes: list[Theme] = []
 
 
 def load_config() -> BridgeConfig:
@@ -49,4 +64,16 @@ def update_bridge_ip(ip: str) -> None:
 def update_favorite_scene_ids(scene_ids: list[str]) -> None:
     config = load_config()
     config.favorite_scene_ids = scene_ids
+    _write_config(config)
+
+
+def add_custom_theme(theme: Theme) -> None:
+    config = load_config()
+    config.custom_themes = [t for t in config.custom_themes if t.id != theme.id] + [theme]
+    _write_config(config)
+
+
+def remove_custom_theme(theme_id: str) -> None:
+    config = load_config()
+    config.custom_themes = [t for t in config.custom_themes if t.id != theme_id]
     _write_config(config)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from app.config import Theme, add_custom_theme, load_config, remove_custom_theme, update_favorite_scene_ids
+from app.config import (
+    DuplicateThemeError,
+    Theme,
+    add_custom_theme,
+    load_config,
+    remove_custom_theme,
+    update_favorite_scene_ids,
+)
 from app.hue_client import (
     BridgeNotConfigured,
     BridgeUnreachable,
@@ -227,10 +234,10 @@ def list_custom_themes() -> list[Theme]:
 def import_theme(theme: Theme):
     if not theme.tokens:
         raise HTTPException(status_code=400, detail="theme must define at least one token")
-    config = load_config()
-    if any(t.id == theme.id for t in config.custom_themes):
+    try:
+        add_custom_theme(theme)
+    except DuplicateThemeError:
         raise HTTPException(status_code=409, detail=f"theme id '{theme.id}' already imported")
-    add_custom_theme(theme)
     return theme
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from app.config import load_config, update_favorite_scene_ids
+from app.config import Theme, add_custom_theme, load_config, remove_custom_theme, update_favorite_scene_ids
 from app.hue_client import (
     BridgeNotConfigured,
     BridgeUnreachable,
@@ -211,6 +211,35 @@ def list_favorites() -> list[str]:
 @app.put("/api/favorites")
 def update_favorites(body: FavoritesUpdate):
     update_favorite_scene_ids(body.scene_ids)
+    return {"status": "ok"}
+
+
+@app.get("/api/themes")
+def list_custom_themes() -> list[Theme]:
+    # Only user-imported themes (issue #21) — the built-in "Default - Dark"
+    # / "Default - Light" themes are frontend code, same split as
+    # favorites/scenes above (local preference vs. bridge/app data).
+    config = load_config()
+    return config.custom_themes
+
+
+@app.post("/api/themes", status_code=201)
+def import_theme(theme: Theme):
+    if not theme.tokens:
+        raise HTTPException(status_code=400, detail="theme must define at least one token")
+    config = load_config()
+    if any(t.id == theme.id for t in config.custom_themes):
+        raise HTTPException(status_code=409, detail=f"theme id '{theme.id}' already imported")
+    add_custom_theme(theme)
+    return theme
+
+
+@app.delete("/api/themes/{theme_id}")
+def delete_custom_theme(theme_id: str):
+    config = load_config()
+    if not any(t.id == theme_id for t in config.custom_themes):
+        raise HTTPException(status_code=404, detail="theme not found")
+    remove_custom_theme(theme_id)
     return {"status": "ok"}
 
 

--- a/backend/tests/test_theme_routes.py
+++ b/backend/tests/test_theme_routes.py
@@ -56,8 +56,12 @@ async def test_import_theme_empty_tokens_is_400(client):
 
 
 async def test_import_theme_duplicate_id_is_409(client, monkeypatch):
+    # add_custom_theme does its own duplicate check internally (against a
+    # lock, to close a check-then-write race — see config.py), using
+    # app.config's load_config rather than main's, so that's what needs
+    # patching here rather than app.main.load_config.
     monkeypatch.setattr(
-        "app.main.load_config",
+        "app.config.load_config",
         lambda: BridgeConfig(custom_themes=[Theme(id="t1", name="Existing", tokens={"--bg": "#000"})]),
     )
 

--- a/backend/tests/test_theme_routes.py
+++ b/backend/tests/test_theme_routes.py
@@ -1,0 +1,88 @@
+from app.config import BridgeConfig, Theme
+
+
+async def test_list_themes_empty_by_default(client):
+    resp = await client.get("/api/themes")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_list_themes_returns_configured_themes(client, monkeypatch):
+    monkeypatch.setattr(
+        "app.main.load_config",
+        lambda: BridgeConfig(custom_themes=[Theme(id="t1", name="Test Theme", tokens={"--bg": "#000"})]),
+    )
+
+    resp = await client.get("/api/themes")
+
+    assert resp.status_code == 200
+    assert resp.json() == [{"id": "t1", "name": "Test Theme", "tokens": {"--bg": "#000"}}]
+
+
+async def test_list_themes_works_without_bridge_configured(client, monkeypatch):
+    monkeypatch.setattr("app.main.load_config", lambda: BridgeConfig())
+
+    resp = await client.get("/api/themes")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_import_theme_persists_and_returns_it(client, monkeypatch):
+    saved = {}
+    monkeypatch.setattr("app.main.load_config", lambda: BridgeConfig())
+    monkeypatch.setattr("app.main.add_custom_theme", lambda theme: saved.setdefault("theme", theme))
+
+    resp = await client.post(
+        "/api/themes", json={"id": "default-light", "name": "Default - Light", "tokens": {"--bg": "#fff"}}
+    )
+
+    assert resp.status_code == 201
+    assert resp.json() == {"id": "default-light", "name": "Default - Light", "tokens": {"--bg": "#fff"}}
+    assert saved["theme"].id == "default-light"
+
+
+async def test_import_theme_missing_field_is_422(client):
+    resp = await client.post("/api/themes", json={"id": "t1", "name": "Test"})
+
+    assert resp.status_code == 422
+
+
+async def test_import_theme_empty_tokens_is_400(client):
+    resp = await client.post("/api/themes", json={"id": "t1", "name": "Test", "tokens": {}})
+
+    assert resp.status_code == 400
+
+
+async def test_import_theme_duplicate_id_is_409(client, monkeypatch):
+    monkeypatch.setattr(
+        "app.main.load_config",
+        lambda: BridgeConfig(custom_themes=[Theme(id="t1", name="Existing", tokens={"--bg": "#000"})]),
+    )
+
+    resp = await client.post("/api/themes", json={"id": "t1", "name": "New", "tokens": {"--bg": "#fff"}})
+
+    assert resp.status_code == 409
+
+
+async def test_delete_theme_removes_it(client, monkeypatch):
+    removed = {}
+    monkeypatch.setattr(
+        "app.main.load_config",
+        lambda: BridgeConfig(custom_themes=[Theme(id="t1", name="Existing", tokens={"--bg": "#000"})]),
+    )
+    monkeypatch.setattr("app.main.remove_custom_theme", lambda theme_id: removed.setdefault("id", theme_id))
+
+    resp = await client.delete("/api/themes/t1")
+
+    assert resp.status_code == 200
+    assert removed["id"] == "t1"
+
+
+async def test_delete_theme_not_found_is_404(client, monkeypatch):
+    monkeypatch.setattr("app.main.load_config", lambda: BridgeConfig())
+
+    resp = await client.delete("/api/themes/missing")
+
+    assert resp.status_code == 404

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,7 +5,9 @@
   import ZoneBrightnessSlider from './ZoneBrightnessSlider.svelte'
   import CreateSceneForm from './CreateSceneForm.svelte'
   import AddFavoriteForm from './AddFavoriteForm.svelte'
-  import { fetchJson, postJson, putJson } from './api.js'
+  import ImportThemeForm from './ImportThemeForm.svelte'
+  import { deleteJson, fetchJson, postJson, putJson } from './api.js'
+  import { applyTheme, builtInThemes, DEFAULT_THEME_ID } from './themes.js'
 
   let lights = $state([])
   let lightsLoading = $state(true)
@@ -57,28 +59,67 @@
     }
   })
 
-  // Warm/cool color palette (issue #20), persisted the same way as
-  // bulbsCollapsed. Applied via a data-palette attribute on <html> rather
-  // than scoped to this component, since app.css's palette tokens (and the
-  // global .dialog-form rules) need it to cascade to the whole page,
-  // including dialogs mounted outside <main>.
-  function readPalette() {
+  // Theme (issue #21, replacing the warm/cool toggle from issue #20).
+  // Built-in themes ship as app code (see themes.js); imported ones are
+  // fetched from the backend below, same split as favorites/scenes (local
+  // preference vs. bridge/app data).
+  let customThemes = $state([])
+  let themesError = $state(null)
+
+  async function loadThemes() {
+    themesError = null
     try {
-      return localStorage.getItem('palette') === 'cool' ? 'cool' : 'warm'
-    } catch {
-      return 'warm'
+      customThemes = await fetchJson('/api/themes')
+    } catch (err) {
+      themesError = err.message
     }
   }
 
-  let palette = $state(readPalette())
-  $effect(() => {
-    document.documentElement.dataset.palette = palette
+  let allThemes = $derived([...builtInThemes, ...customThemes])
+
+  function readThemeId() {
     try {
-      localStorage.setItem('palette', palette)
+      return localStorage.getItem('themeId') ?? DEFAULT_THEME_ID
     } catch {
-      // Ignore — persistence is a nice-to-have, not required for the toggle to work.
+      return DEFAULT_THEME_ID
+    }
+  }
+
+  let themeId = $state(readThemeId())
+  // Falls back to the default theme if the persisted id no longer resolves
+  // to anything — e.g. a previously-imported theme was removed elsewhere.
+  let activeTheme = $derived(
+    allThemes.find((t) => t.id === themeId) ?? allThemes.find((t) => t.id === DEFAULT_THEME_ID)
+  )
+
+  $effect(() => {
+    if (!activeTheme) return
+    applyTheme(activeTheme)
+    try {
+      localStorage.setItem('themeId', themeId)
+    } catch {
+      // Ignore — persistence is a nice-to-have, not required for the theme to apply.
     }
   })
+
+  // Whether the "Import Theme" dialog is open (same one-dialog-at-a-time
+  // shape as addFavoriteFormOpen).
+  let importThemeFormOpen = $state(false)
+
+  async function importTheme(theme) {
+    const imported = await postJson('/api/themes', theme)
+    customThemes = [...customThemes, imported]
+    themeId = imported.id
+  }
+
+  // Only ever offered for a custom (imported) theme — see the template,
+  // built-in themes have no delete control. Falls back to the default
+  // theme if the one just deleted was active.
+  async function deleteTheme(id) {
+    await deleteJson(`/api/themes/${id}`)
+    customThemes = customThemes.filter((t) => t.id !== id)
+    if (themeId === id) themeId = DEFAULT_THEME_ID
+  }
 
   async function loadLights() {
     lightsLoading = true
@@ -181,6 +222,7 @@
     loadScenes()
     loadZones()
     loadFavorites()
+    loadThemes()
   })
 
   // Buckets scenes under the zone they belong to. Scenes tied to a Room, an
@@ -510,15 +552,41 @@
       <h1>Hue Light Control</h1>
       <p class="subtitle">Bulbs and scenes on your local Hue bridge</p>
     </div>
-    <div class="palette-toggle" role="group" aria-label="Color palette">
-      <button type="button" class:active={palette === 'warm'} onclick={() => (palette = 'warm')}>
-        Warm
-      </button>
-      <button type="button" class:active={palette === 'cool'} onclick={() => (palette = 'cool')}>
-        Cool
-      </button>
+    <div class="theme-picker">
+      <label>
+        <span class="sr-only">Theme</span>
+        <select bind:value={themeId} aria-label="Theme">
+          {#each builtInThemes as theme (theme.id)}
+            <option value={theme.id}>{theme.name}</option>
+          {/each}
+          {#if customThemes.length > 0}
+            <optgroup label="Imported">
+              {#each customThemes as theme (theme.id)}
+                <option value={theme.id}>{theme.name}</option>
+              {/each}
+            </optgroup>
+          {/if}
+        </select>
+      </label>
+      {#if customThemes.some((t) => t.id === themeId)}
+        <button type="button" onclick={() => deleteTheme(themeId)} aria-label="Delete current theme">
+          Delete
+        </button>
+      {/if}
+      <button type="button" onclick={() => (importThemeFormOpen = true)}>+ Import</button>
     </div>
   </div>
+
+  {#if themesError}
+    <p class="error">
+      Couldn't load imported themes ({themesError}).
+      <button onclick={loadThemes}>Retry</button>
+    </p>
+  {/if}
+
+  {#if importThemeFormOpen}
+    <ImportThemeForm onImport={importTheme} onClose={() => (importThemeFormOpen = false)} />
+  {/if}
 
   <div class="layout">
     <aside class="bulbs-panel" class:collapsed={bulbsCollapsed}>
@@ -672,35 +740,47 @@
     font-size: 0.95rem;
   }
 
-  .palette-toggle {
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  .theme-picker {
     display: flex;
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    background: var(--surface-alt);
-    padding: 0.2rem;
+    align-items: center;
+    gap: 0.5rem;
     flex-shrink: 0;
   }
 
-  .palette-toggle button {
+  .theme-picker select {
+    font: inherit;
+    font-size: 0.85rem;
+    padding: 0.35rem 0.6rem;
+    border-radius: var(--radius-pill);
+    border: 1px solid var(--border);
+    background: var(--surface-alt);
+    color: inherit;
+  }
+
+  .theme-picker button {
     font: inherit;
     font-size: 0.85rem;
     font-weight: 600;
     padding: 0.35rem 0.9rem;
-    border-radius: 999px;
-    border: none;
-    background: none;
-    color: var(--text-muted);
+    border-radius: var(--radius-pill);
+    border: 1px solid var(--border);
+    background: var(--surface-alt);
+    color: inherit;
     cursor: pointer;
-    transition: background-color 0.15s ease, color 0.15s ease;
+    transition: filter 0.15s ease;
   }
 
-  .palette-toggle button.active {
-    background: var(--accent);
-    color: var(--accent-text);
-  }
-
-  .palette-toggle button:not(.active):hover {
-    color: var(--text);
+  .theme-picker button:hover {
+    filter: brightness(0.95);
   }
 
   .layout {
@@ -757,7 +837,7 @@
     width: 1.75rem;
     height: 1.75rem;
     padding: 0;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     border: 1px solid var(--border);
     background: var(--surface-alt);
     color: inherit;
@@ -796,7 +876,7 @@
     font-size: 0.85rem;
     font-weight: 600;
     padding: 0.4rem 0.9rem;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     border: 1px solid var(--border);
     background: var(--surface-alt);
     color: inherit;
@@ -816,7 +896,7 @@
 
   .zone-group {
     border: 1px solid var(--border);
-    border-radius: 1rem;
+    border-radius: var(--radius-lg);
     background: var(--surface-alt);
     padding: 1.25rem;
   }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -115,10 +115,26 @@
   // Only ever offered for a custom (imported) theme — see the template,
   // built-in themes have no delete control. Falls back to the default
   // theme if the one just deleted was active.
+  //
+  // Guarded against overlapping double-click requests and surfaces a
+  // failure via themesError, same pattern as SceneCard's removeFavorite
+  // (removePending/removeError) — otherwise a double-click's second DELETE
+  // 404s (the first already removed it) and fails silently.
+  let deletingThemeId = $state(null)
+
   async function deleteTheme(id) {
-    await deleteJson(`/api/themes/${id}`)
-    customThemes = customThemes.filter((t) => t.id !== id)
-    if (themeId === id) themeId = DEFAULT_THEME_ID
+    if (deletingThemeId) return
+    deletingThemeId = id
+    themesError = null
+    try {
+      await deleteJson(`/api/themes/${id}`)
+      customThemes = customThemes.filter((t) => t.id !== id)
+      if (themeId === id) themeId = DEFAULT_THEME_ID
+    } catch (err) {
+      themesError = err.message
+    } finally {
+      deletingThemeId = null
+    }
   }
 
   async function loadLights() {
@@ -569,7 +585,12 @@
         </select>
       </label>
       {#if customThemes.some((t) => t.id === themeId)}
-        <button type="button" onclick={() => deleteTheme(themeId)} aria-label="Delete current theme">
+        <button
+          type="button"
+          onclick={() => deleteTheme(themeId)}
+          disabled={deletingThemeId === themeId}
+          aria-label="Delete current theme"
+        >
           Delete
         </button>
       {/if}

--- a/frontend/src/BrightnessSlider.svelte
+++ b/frontend/src/BrightnessSlider.svelte
@@ -34,7 +34,7 @@
     appearance: none;
     -webkit-appearance: none;
     height: 0.4rem;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     background: var(--surface-alt);
     outline: none;
   }
@@ -64,7 +64,7 @@
 
   input[type='range']::-moz-range-progress {
     background: var(--accent);
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     height: 0.4rem;
   }
 

--- a/frontend/src/FormDialog.svelte
+++ b/frontend/src/FormDialog.svelte
@@ -39,7 +39,7 @@
 <style>
   dialog {
     border: 1px solid var(--border);
-    border-radius: 0.75rem;
+    border-radius: var(--radius-md);
     padding: 1.25rem;
     background: var(--surface);
     color: inherit;

--- a/frontend/src/ImportThemeForm.svelte
+++ b/frontend/src/ImportThemeForm.svelte
@@ -1,0 +1,81 @@
+<script>
+  import FormDialog from './FormDialog.svelte'
+  import { missingTokens } from './themes.js'
+
+  let { onImport, onClose } = $props()
+
+  let dialogEl = $state(null)
+  let fileName = $state(null)
+  let theme = $state(null)
+  let submitting = $state(false)
+  let error = $state(null)
+
+  async function handleFileChange(event) {
+    error = null
+    theme = null
+    const file = event.target.files?.[0]
+    if (!file) return
+    fileName = file.name
+    let parsed
+    try {
+      parsed = JSON.parse(await file.text())
+    } catch {
+      error = 'That file is not valid JSON.'
+      return
+    }
+    if (typeof parsed?.id !== 'string' || !parsed.id) {
+      error = 'Theme is missing an "id".'
+      return
+    }
+    if (typeof parsed?.name !== 'string' || !parsed.name) {
+      error = 'Theme is missing a "name".'
+      return
+    }
+    const missing = missingTokens(parsed.tokens)
+    if (missing.length > 0) {
+      error = `Theme is missing required tokens: ${missing.join(', ')}`
+      return
+    }
+    theme = parsed
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    if (!theme || submitting) return
+    submitting = true
+    error = null
+    try {
+      await onImport(theme)
+      dialogEl?.close()
+    } catch (err) {
+      error = err.message
+      submitting = false
+    }
+  }
+</script>
+
+<FormDialog bind:dialogEl {onClose}>
+  <form class="dialog-form" onsubmit={handleSubmit}>
+    <h2>Import Theme</h2>
+
+    <label class="field">
+      <span>Theme JSON file</span>
+      <input type="file" accept="application/json,.json" onchange={handleFileChange} />
+    </label>
+
+    {#if fileName && !error}
+      <p class="hint">"{theme?.name}" ready to import.</p>
+    {/if}
+
+    {#if error}
+      <p class="error">{error}</p>
+    {/if}
+
+    <div class="actions">
+      <button type="button" onclick={() => dialogEl?.close()}>Cancel</button>
+      <button type="submit" class="primary" disabled={!theme || submitting}>
+        {submitting ? 'Importing…' : 'Import'}
+      </button>
+    </div>
+  </form>
+</FormDialog>

--- a/frontend/src/LightCard.svelte
+++ b/frontend/src/LightCard.svelte
@@ -107,7 +107,7 @@
 <style>
   .card {
     border: 1px solid var(--border);
-    border-radius: 0.75rem;
+    border-radius: var(--radius-md);
     padding: 1rem;
     display: flex;
     flex-direction: column;
@@ -184,7 +184,7 @@
   .badge {
     font-size: 0.75rem;
     padding: 0.15rem 0.5rem;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     background: var(--surface-alt);
     color: var(--text-muted);
     width: fit-content;

--- a/frontend/src/SceneCard.svelte
+++ b/frontend/src/SceneCard.svelte
@@ -168,7 +168,7 @@
 <style>
   .card {
     border: 1px solid var(--border);
-    border-radius: 0.75rem;
+    border-radius: var(--radius-md);
     display: flex;
     flex-direction: column;
     background: var(--surface);
@@ -300,7 +300,7 @@
   .badge {
     font-size: 0.75rem;
     padding: 0.15rem 0.5rem;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     background: var(--surface-alt);
     color: var(--text-muted);
     width: fit-content;

--- a/frontend/src/ZoneBrightnessSlider.svelte
+++ b/frontend/src/ZoneBrightnessSlider.svelte
@@ -89,7 +89,7 @@
   .badge {
     font-size: 0.75rem;
     padding: 0.15rem 0.5rem;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     width: fit-content;
     flex-shrink: 0;
   }
@@ -104,7 +104,7 @@
     font-size: 0.85rem;
     font-weight: 600;
     padding: 0.4rem 0.9rem;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     border: 1px solid var(--border);
     background: var(--surface-alt);
     cursor: pointer;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -30,3 +30,7 @@ export function putJson(url, body) {
 export function postJson(url, body) {
   return fetchJson(url, { method: 'POST', body })
 }
+
+export function deleteJson(url) {
+  return fetchJson(url, { method: 'DELETE' })
+}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,41 +1,37 @@
 :root {
-  color-scheme: light dark;
-  font-family: -apple-system, system-ui, sans-serif;
+  /* Fallback values only — matches the "Default - Dark" theme in themes.js.
+     App.svelte sets these as inline styles on <html> for whichever theme is
+     selected (issue #21), which take precedence the moment JS runs; this
+     :root block just avoids an unstyled flash before that happens (or if JS
+     is unavailable). Every color/shape elsewhere in the app should reference
+     one of these tokens rather than hardcoding a value directly, so it
+     repaints when the theme switches. */
+  --bg: #1c1712;
+  --surface: #241d16;
+  --surface-alt: #2a2018;
+  --border: #3d3020;
+  --text: #f2e6d8;
+  --text-muted: #b8a488;
+  --accent: #e8952f;
+  --accent-text: #1c1712;
+  --accent-soft-bg: #3d2a12;
+  --accent-soft-border: #6b4a1e;
+  --shadow-color: rgba(0, 0, 0, 0.35);
+  --error-bg: #3d211f;
+  --error-text: #f0958a;
 
-  /* Warm palette (default) — issue #20's two selectable themes, toggled by
-     setting data-palette on <html> (see App.svelte). Every color elsewhere
-     in the app should reference one of these tokens rather than hardcoding
-     light-dark() directly, so it repaints when the palette switches. */
-  --bg: light-dark(#faf6f1, #1c1712);
-  --surface: light-dark(#ffffff, #241d16);
-  --surface-alt: light-dark(#f5ede4, #2a2018);
-  --border: light-dark(#e0d3c2, #3d3020);
-  --text: light-dark(#2a2015, #f2e6d8);
-  --text-muted: light-dark(#8a7259, #b8a488);
-  --accent: light-dark(#c2650a, #e8952f);
-  --accent-text: light-dark(#fff8f0, #1c1712);
-  --accent-soft-bg: light-dark(#ffe9d5, #3d2a12);
-  --accent-soft-border: light-dark(#f0b876, #6b4a1e);
-  --shadow-color: light-dark(rgba(40, 25, 10, 0.1), rgba(0, 0, 0, 0.35));
+  --font-family: -apple-system, system-ui, sans-serif;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-pill: 999px;
+  /* Hints native form controls (scrollbars, range inputs, etc.) to render
+     for whichever mode the active theme actually is, since themes are now
+     fixed palettes rather than the light-dark() pairs issue #20 used. */
+  --color-scheme: dark;
 
-  /* Semantic — errors read as "error" regardless of palette, so these don't
-     vary between warm and cool. */
-  --error-bg: light-dark(#fbe3e0, #3d211f);
-  --error-text: light-dark(#a3392c, #f0958a);
-}
-
-[data-palette='cool'] {
-  --bg: light-dark(#f1f6f8, #10171c);
-  --surface: light-dark(#ffffff, #17212a);
-  --surface-alt: light-dark(#e8eef2, #1c2830);
-  --border: light-dark(#ccdae3, #2b3c47);
-  --text: light-dark(#16232b, #e4edf2);
-  --text-muted: light-dark(#5f7684, #93a8b3);
-  --accent: light-dark(#1f6fb2, #4fa3e0);
-  --accent-text: light-dark(#f5fbff, #0b1116);
-  --accent-soft-bg: light-dark(#dcedfa, #16283a);
-  --accent-soft-border: light-dark(#8ec3e8, #235279);
-  --shadow-color: light-dark(rgba(10, 30, 45, 0.1), rgba(0, 0, 0, 0.35));
+  font-family: var(--font-family);
+  color-scheme: var(--color-scheme);
 }
 
 *,
@@ -92,7 +88,7 @@ main {
 .dialog-form select {
   font: inherit;
   padding: 0.4rem 0.5rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--surface);
   color: inherit;
@@ -105,7 +101,7 @@ main {
   max-height: 10rem;
   overflow-y: auto;
   padding: 0.5rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-sm);
   background: var(--surface-alt);
 }
 
@@ -141,7 +137,7 @@ main {
 .dialog-form button {
   font: inherit;
   padding: 0.4rem 0.9rem;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border);
   background: var(--surface-alt);
   color: inherit;

--- a/frontend/src/themes.js
+++ b/frontend/src/themes.js
@@ -1,0 +1,100 @@
+// Tokens every theme must define (issue #21) — the full set app.css and
+// component styles actually read. Kept here (not derived from app.css) so
+// importTheme can validate an imported theme up front, rather than letting
+// it apply half-defined and leave stale values from whatever theme was
+// active before it.
+export const REQUIRED_TOKENS = [
+  '--bg',
+  '--surface',
+  '--surface-alt',
+  '--border',
+  '--text',
+  '--text-muted',
+  '--accent',
+  '--accent-text',
+  '--accent-soft-bg',
+  '--accent-soft-border',
+  '--shadow-color',
+  '--error-bg',
+  '--error-text',
+  '--font-family',
+  '--radius-sm',
+  '--radius-md',
+  '--radius-lg',
+  '--radius-pill',
+  '--color-scheme',
+]
+
+// Built-in themes ship as app code, not user data — unlike imported themes
+// (backend's custom_themes, see api.js), these don't need a round trip to
+// the backend just to list them.
+export const builtInThemes = [
+  {
+    id: 'default-dark',
+    name: 'Default - Dark',
+    tokens: {
+      '--bg': '#1c1712',
+      '--surface': '#241d16',
+      '--surface-alt': '#2a2018',
+      '--border': '#3d3020',
+      '--text': '#f2e6d8',
+      '--text-muted': '#b8a488',
+      '--accent': '#e8952f',
+      '--accent-text': '#1c1712',
+      '--accent-soft-bg': '#3d2a12',
+      '--accent-soft-border': '#6b4a1e',
+      '--shadow-color': 'rgba(0, 0, 0, 0.35)',
+      '--error-bg': '#3d211f',
+      '--error-text': '#f0958a',
+      '--font-family': '-apple-system, system-ui, sans-serif',
+      '--radius-sm': '0.5rem',
+      '--radius-md': '0.75rem',
+      '--radius-lg': '1rem',
+      '--radius-pill': '999px',
+      '--color-scheme': 'dark',
+    },
+  },
+  {
+    id: 'default-light',
+    name: 'Default - Light',
+    tokens: {
+      '--bg': '#faf6f1',
+      '--surface': '#ffffff',
+      '--surface-alt': '#f5ede4',
+      '--border': '#e0d3c2',
+      '--text': '#2a2015',
+      '--text-muted': '#8a7259',
+      '--accent': '#c2650a',
+      '--accent-text': '#fff8f0',
+      '--accent-soft-bg': '#ffe9d5',
+      '--accent-soft-border': '#f0b876',
+      '--shadow-color': 'rgba(40, 25, 10, 0.1)',
+      '--error-bg': '#fbe3e0',
+      '--error-text': '#a3392c',
+      '--font-family': '-apple-system, system-ui, sans-serif',
+      '--radius-sm': '0.5rem',
+      '--radius-md': '0.75rem',
+      '--radius-lg': '1rem',
+      '--radius-pill': '999px',
+      '--color-scheme': 'light',
+    },
+  },
+]
+
+export const DEFAULT_THEME_ID = 'default-dark'
+
+// Applied to <html> rather than scoped to a component, same reasoning as
+// the old data-palette attribute it replaces: tokens need to cascade to the
+// whole page, including dialogs mounted outside <main>.
+export function applyTheme(theme) {
+  const root = document.documentElement.style
+  for (const token of REQUIRED_TOKENS) {
+    root.setProperty(token, theme.tokens[token] ?? '')
+  }
+}
+
+// Used by the import dialog to reject a theme missing tokens the app
+// actually reads, rather than letting it apply with silent gaps.
+export function missingTokens(tokens) {
+  return REQUIRED_TOKENS.filter((token) => !tokens || typeof tokens[token] !== 'string' || tokens[token] === '')
+}


### PR DESCRIPTION
## Summary
- Closes #21: replaces the warm/cool palette toggle (#20) with a "Theme" dropdown supporting two built-in themes and JSON import of custom ones.
- "Default - Dark" (the current warm-dark palette, now the app default) and "Default - Light" (a light version of the same theme) ship as frontend code (`themes.js`).
- Themes cover more than color — `--font-family`, `--radius-sm/md/lg/pill`, and `--color-scheme` are theme-controlled tokens too, so future themes (issues #42 Wipeout, #43 LCARS, #45 Claude-Designer themes) can restyle shape/typography without touching component code.
- Import: `POST /api/themes` (JSON file upload in the UI), validated against a required-token list before it's ever applied; imported themes persist in `backend/config.yaml` (`custom_themes`), same pattern as favorites. `DELETE /api/themes/{id}` removes one.
- `GET /api/themes` lists only imported themes; built-ins aren't round-tripped through the backend since they're not user data.

## Test plan
- [x] `pytest` in `backend/` — 79 passed, including new `test_theme_routes.py`
- [x] `npm run build` in `frontend/` — succeeds
- [x] Manually exercised in a browser: switched Default - Dark → Default - Light (repaints correctly), imported a custom theme via file upload (validated, applied — different font/radii/colors), deleted it (reverts to Default - Dark), confirmed selection persists via localStorage across the built-ins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)