### PR TITLE
Add Cool - Dark / Cool - Light themes; widen theme dropdown

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -780,7 +780,8 @@
   .theme-picker select {
     font: inherit;
     font-size: 0.85rem;
-    padding: 0.35rem 0.6rem;
+    padding: 0.35rem 1.6rem 0.35rem 0.9rem;
+    min-width: 9rem;
     border-radius: var(--radius-pill);
     border: 1px solid var(--border);
     background: var(--surface-alt);

--- a/frontend/src/themes.js
+++ b/frontend/src/themes.js
@@ -79,6 +79,61 @@ export const builtInThemes = [
       '--color-scheme': 'light',
     },
   },
+  {
+    // Recreates issue #20's cool palette (dark variant) — the values below
+    // are the same ones that used to live under app.css's
+    // [data-palette='cool'] light-dark(light, dark) pairs, before issue #21
+    // replaced the toggle with named themes.
+    id: 'cool-dark',
+    name: 'Cool - Dark',
+    tokens: {
+      '--bg': '#10171c',
+      '--surface': '#17212a',
+      '--surface-alt': '#1c2830',
+      '--border': '#2b3c47',
+      '--text': '#e4edf2',
+      '--text-muted': '#93a8b3',
+      '--accent': '#4fa3e0',
+      '--accent-text': '#0b1116',
+      '--accent-soft-bg': '#16283a',
+      '--accent-soft-border': '#235279',
+      '--shadow-color': 'rgba(0, 0, 0, 0.35)',
+      '--error-bg': '#3d211f',
+      '--error-text': '#f0958a',
+      '--font-family': '-apple-system, system-ui, sans-serif',
+      '--radius-sm': '0.5rem',
+      '--radius-md': '0.75rem',
+      '--radius-lg': '1rem',
+      '--radius-pill': '999px',
+      '--color-scheme': 'dark',
+    },
+  },
+  {
+    // Recreates issue #20's cool palette (light variant) — see cool-dark.
+    id: 'cool-light',
+    name: 'Cool - Light',
+    tokens: {
+      '--bg': '#f1f6f8',
+      '--surface': '#ffffff',
+      '--surface-alt': '#e8eef2',
+      '--border': '#ccdae3',
+      '--text': '#16232b',
+      '--text-muted': '#5f7684',
+      '--accent': '#1f6fb2',
+      '--accent-text': '#f5fbff',
+      '--accent-soft-bg': '#dcedfa',
+      '--accent-soft-border': '#8ec3e8',
+      '--shadow-color': 'rgba(10, 30, 45, 0.1)',
+      '--error-bg': '#fbe3e0',
+      '--error-text': '#a3392c',
+      '--font-family': '-apple-system, system-ui, sans-serif',
+      '--radius-sm': '0.5rem',
+      '--radius-md': '0.75rem',
+      '--radius-lg': '1rem',
+      '--radius-pill': '999px',
+      '--color-scheme': 'light',
+    },
+  },
 ]
 
 export const DEFAULT_THEME_ID = 'default-dark'


### PR DESCRIPTION
## Summary
- Recreates issue #20's cool palette as two built-in themes (\`Cool - Dark\`, \`Cool - Light\`) alongside the existing warm-derived Default - Dark/Light, using the same color values that used to live under app.css's `[data-palette='cool']` block before #21's theme system replaced the toggle.
- Widens the theme `<select>` and adds right padding so its chevron isn't flush against the pill's edge (UI nit from #64 review).

## Test plan
- [x] `pytest` in `backend/` — 79 passed (unaffected, no backend changes)
- [x] `npm run build` in `frontend/` — succeeds
- [x] Manually verified both new themes render correctly in a browser and the widened dropdown looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)