### PR TITLE
Proactively rediscover the bridge IP on page load

### DIFF
--- a/backend/app/bridge_discovery.py
+++ b/backend/app/bridge_discovery.py
@@ -7,7 +7,14 @@ from typing import Optional
 
 import httpx
 
+from app.config import BridgeConfig, load_config, update_bridge_ip
+
 logger = logging.getLogger(__name__)
+
+# Serializes rediscovery so concurrent callers (e.g. the frontend's proactive
+# health check racing a panel's own failed request) don't each run their own
+# SSDP/cloud search and race to write config.yaml.
+_rediscovery_lock = asyncio.Lock()
 
 CLOUD_DISCOVERY_URL = "https://discovery.meethue.com/"
 
@@ -135,3 +142,36 @@ async def rediscover_bridge_ip(api_key: str) -> Optional[str]:
 
     _last_failure_at = time.monotonic()
     return None
+
+
+async def ensure_bridge_reachable(config: BridgeConfig) -> dict:
+    """Proactively verify the configured bridge_ip is still valid, repairing
+    config.yaml via rediscovery if it isn't. Meant to be called once on page
+    load (via /api/health) so a drifted IP self-heals before the frontend's
+    panels fire their own requests, rather than only reacting to a failure.
+
+    Never raises — a health endpoint needs a clean status even when the
+    bridge is genuinely unreachable.
+    """
+    if not config.bridge_ip or not config.api_key:
+        return {"reachable": False, "configured": False, "bridge_ip": None}
+
+    if await _verify_bridge(config.bridge_ip, config.api_key):
+        return {"reachable": True, "configured": True, "bridge_ip": config.bridge_ip}
+
+    async with _rediscovery_lock:
+        # A concurrent caller (e.g. a panel's own failed request) may have
+        # already repaired config.yaml while we were waiting for the lock.
+        current = load_config()
+        if current.bridge_ip and current.bridge_ip != config.bridge_ip:
+            if await _verify_bridge(current.bridge_ip, current.api_key):
+                return {"reachable": True, "configured": True, "bridge_ip": current.bridge_ip}
+
+        new_ip = await rediscover_bridge_ip(config.api_key)
+        if new_ip is None:
+            return {"reachable": False, "configured": True, "bridge_ip": config.bridge_ip}
+
+        if new_ip != config.bridge_ip:
+            logger.info("Bridge IP changed (%s -> %s), updating config.yaml", config.bridge_ip, new_ip)
+            update_bridge_ip(new_ip)
+        return {"reachable": True, "configured": True, "bridge_ip": new_ip}

--- a/backend/app/bridge_discovery.py
+++ b/backend/app/bridge_discovery.py
@@ -13,8 +13,9 @@ logger = logging.getLogger(__name__)
 
 # Serializes rediscovery so concurrent callers (e.g. the frontend's proactive
 # health check racing a panel's own failed request) don't each run their own
-# SSDP/cloud search and race to write config.yaml.
-_rediscovery_lock = asyncio.Lock()
+# SSDP/cloud search and race to write config.yaml. Shared with hue_client.py
+# (not underscore-prefixed, since it's intentionally used across modules).
+rediscovery_lock = asyncio.Lock()
 
 CLOUD_DISCOVERY_URL = "https://discovery.meethue.com/"
 
@@ -144,6 +145,32 @@ async def rediscover_bridge_ip(api_key: str) -> Optional[str]:
     return None
 
 
+async def resolve_working_bridge_ip(stale_ip: str, api_key: str) -> Optional[str]:
+    """Find a working bridge IP to replace one that just failed, persisting it
+    to config.yaml if it's actually new. Shared by hue_client._bridge_request
+    (reactive: a request against stale_ip just failed) and
+    ensure_bridge_reachable (proactive: stale_ip failed a live verify).
+
+    Owns rediscovery_lock itself, so a concurrent caller's rediscovery
+    (already verified, by construction, before it got persisted) is reused
+    instead of triggering a second SSDP/cloud search. Returns None only if
+    discovery itself comes up empty — never raises.
+    """
+    async with rediscovery_lock:
+        current = load_config()
+        if current.bridge_ip and current.bridge_ip != stale_ip:
+            return current.bridge_ip
+
+        new_ip = await rediscover_bridge_ip(api_key)
+        if new_ip is None:
+            return None
+
+        if new_ip != stale_ip:
+            logger.info("Bridge IP changed (%s -> %s), updating config.yaml", stale_ip, new_ip)
+            update_bridge_ip(new_ip)
+        return new_ip
+
+
 async def ensure_bridge_reachable(config: BridgeConfig) -> dict:
     """Proactively verify the configured bridge_ip is still valid, repairing
     config.yaml via rediscovery if it isn't. Meant to be called once on page
@@ -159,19 +186,7 @@ async def ensure_bridge_reachable(config: BridgeConfig) -> dict:
     if await _verify_bridge(config.bridge_ip, config.api_key):
         return {"reachable": True, "configured": True, "bridge_ip": config.bridge_ip}
 
-    async with _rediscovery_lock:
-        # A concurrent caller (e.g. a panel's own failed request) may have
-        # already repaired config.yaml while we were waiting for the lock.
-        current = load_config()
-        if current.bridge_ip and current.bridge_ip != config.bridge_ip:
-            if await _verify_bridge(current.bridge_ip, current.api_key):
-                return {"reachable": True, "configured": True, "bridge_ip": current.bridge_ip}
-
-        new_ip = await rediscover_bridge_ip(config.api_key)
-        if new_ip is None:
-            return {"reachable": False, "configured": True, "bridge_ip": config.bridge_ip}
-
-        if new_ip != config.bridge_ip:
-            logger.info("Bridge IP changed (%s -> %s), updating config.yaml", config.bridge_ip, new_ip)
-            update_bridge_ip(new_ip)
-        return {"reachable": True, "configured": True, "bridge_ip": new_ip}
+    new_ip = await resolve_working_bridge_ip(config.bridge_ip, config.api_key)
+    if new_ip is None:
+        return {"reachable": False, "configured": True, "bridge_ip": config.bridge_ip}
+    return {"reachable": True, "configured": True, "bridge_ip": new_ip}

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -7,8 +7,8 @@ from typing import Optional
 import httpx
 from pydantic import BaseModel
 
-from app.bridge_discovery import _rediscovery_lock, rediscover_bridge_ip
-from app.config import BridgeConfig, load_config, update_bridge_ip
+from app.bridge_discovery import resolve_working_bridge_ip
+from app.config import BridgeConfig
 
 logger = logging.getLogger(__name__)
 
@@ -305,36 +305,21 @@ async def _bridge_request(
         if method == "POST":
             raise BridgeUnreachable("could not reach the bridge") from exc
 
-    async with _rediscovery_lock:
-        # A concurrent request may have already rediscovered and persisted a
-        # working IP while we were waiting for the lock — try that first.
-        current_ip = load_config().bridge_ip
-        if current_ip and current_ip != config.bridge_ip:
-            try:
-                return await _request_bridge(current_ip, config.api_key, path, method=method, json_body=json_body)
-            except httpx.HTTPStatusError as exc:
-                logger.warning("Bridge at %s rejected the request: %s", current_ip, exc)
-                raise BridgeUnreachable("bridge rejected the request") from exc
-            except httpx.HTTPError:
-                pass
+    # resolve_working_bridge_ip reuses a concurrent caller's already-verified
+    # fix if one just landed (e.g. the frontend's proactive health check),
+    # otherwise runs SSDP/cloud discovery itself and persists the result.
+    new_ip = await resolve_working_bridge_ip(config.bridge_ip, config.api_key)
+    if new_ip is None:
+        raise BridgeUnreachable("could not reach the bridge")
 
-        new_ip = await rediscover_bridge_ip(config.api_key)
-        if new_ip is None:
-            raise BridgeUnreachable("could not reach the bridge")
-
-        try:
-            data = await _request_bridge(new_ip, config.api_key, path, method=method, json_body=json_body)
-        except httpx.HTTPStatusError as exc:
-            logger.warning("Bridge at %s rejected the request: %s", new_ip, exc)
-            raise BridgeUnreachable("bridge rejected the request") from exc
-        except httpx.HTTPError as exc:
-            logger.warning("Rediscovered bridge at %s also unreachable: %s", new_ip, exc)
-            raise BridgeUnreachable("could not reach the bridge") from exc
-
-        if new_ip != config.bridge_ip:
-            logger.info("Bridge IP changed (%s -> %s), updating config.yaml", config.bridge_ip, new_ip)
-            update_bridge_ip(new_ip)
-        return data
+    try:
+        return await _request_bridge(new_ip, config.api_key, path, method=method, json_body=json_body)
+    except httpx.HTTPStatusError as exc:
+        logger.warning("Bridge at %s rejected the request: %s", new_ip, exc)
+        raise BridgeUnreachable("bridge rejected the request") from exc
+    except httpx.HTTPError as exc:
+        logger.warning("Rediscovered bridge at %s also unreachable: %s", new_ip, exc)
+        raise BridgeUnreachable("could not reach the bridge") from exc
 
 
 async def _request_bridge_v2(

--- a/backend/app/hue_client.py
+++ b/backend/app/hue_client.py
@@ -7,15 +7,10 @@ from typing import Optional
 import httpx
 from pydantic import BaseModel
 
-from app.bridge_discovery import rediscover_bridge_ip
+from app.bridge_discovery import _rediscovery_lock, rediscover_bridge_ip
 from app.config import BridgeConfig, load_config, update_bridge_ip
 
 logger = logging.getLogger(__name__)
-
-# Serializes rediscovery so concurrent requests (e.g. the frontend's
-# lights + scenes calls firing together) don't each run their own SSDP/cloud
-# search and race to write config.yaml.
-_rediscovery_lock = asyncio.Lock()
 
 
 class BridgeNotConfigured(Exception):
@@ -272,6 +267,13 @@ async def _request_bridge(
 async def _bridge_request(
     config: BridgeConfig, path: str, *, method: str = "GET", json_body: Optional[dict] = None
 ) -> dict:
+    # The frontend now runs a proactive verify-and-repair check
+    # (bridge_discovery.ensure_bridge_reachable, via /api/health) on page
+    # load, so a drifted IP is typically already fixed before any panel gets
+    # here. This path remains for drift that happens mid-session and for a
+    # genuine network-level failure — see the HTTPStatusError handling below
+    # for why a merely-rejected request doesn't also trigger rediscovery.
+    #
     # On a genuine network failure, the retry path below blindly re-sends
     # the same json_body against a rediscovered/newly-current IP. That's
     # fine for idempotent methods (GET, and PUT writes like "set brightness

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from app.bridge_discovery import ensure_bridge_reachable
 from app.config import (
     DuplicateThemeError,
     Theme,
@@ -59,9 +60,10 @@ async def bridge_unreachable_handler(request: Request, exc: BridgeUnreachable) -
 
 
 @app.get("/api/health")
-def health():
+async def health():
     config = load_config()
-    return {"status": "ok", "bridge_configured": config.bridge_ip is not None}
+    status = await ensure_bridge_reachable(config)
+    return {"status": "ok", **status}
 
 
 @app.get("/api/lights")

--- a/backend/tests/test_bridge_discovery.py
+++ b/backend/tests/test_bridge_discovery.py
@@ -1,0 +1,80 @@
+import respx
+from httpx import Response
+
+from app.bridge_discovery import ensure_bridge_reachable
+from app.config import BridgeConfig
+
+BRIDGE_URL = "http://192.168.x.x/api/test-api-key"
+
+
+async def test_ensure_bridge_reachable_not_configured():
+    # No network calls should be attempted at all -- respx isn't even
+    # active here, so any HTTP call would error with a real connection.
+    config = BridgeConfig(bridge_ip=None, api_key=None)
+
+    result = await ensure_bridge_reachable(config)
+
+    assert result == {"reachable": False, "configured": False, "bridge_ip": None}
+
+
+@respx.mock
+async def test_ensure_bridge_reachable_verifies_current_ip_ok(monkeypatch):
+    config = BridgeConfig(bridge_ip="192.168.x.x", api_key="test-api-key")
+
+    async def fail_if_called(api_key):
+        raise AssertionError("rediscovery should not run when the current IP still verifies")
+
+    monkeypatch.setattr("app.bridge_discovery.rediscover_bridge_ip", fail_if_called)
+
+    respx.get(f"{BRIDGE_URL}/config").mock(return_value=Response(200, json={"name": "bridge"}))
+
+    result = await ensure_bridge_reachable(config)
+
+    assert result == {"reachable": True, "configured": True, "bridge_ip": "192.168.x.x"}
+
+
+@respx.mock
+async def test_ensure_bridge_reachable_repairs_stale_ip(monkeypatch):
+    # Simulates the exact gap being fixed: the stale IP belongs to some other
+    # live device that answers, but not with our bridge's shape.
+    config = BridgeConfig(bridge_ip="192.168.x.x", api_key="test-api-key")
+
+    respx.get(f"{BRIDGE_URL}/config").mock(
+        return_value=Response(200, json=[{"error": {"description": "unauthorized user"}}])
+    )
+
+    async def fake_rediscover(api_key):
+        return "192.168.x.y"
+
+    updated = {}
+
+    def fake_update_bridge_ip(ip):
+        updated["ip"] = ip
+
+    monkeypatch.setattr("app.bridge_discovery.load_config", lambda: config)
+    monkeypatch.setattr("app.bridge_discovery.rediscover_bridge_ip", fake_rediscover)
+    monkeypatch.setattr("app.bridge_discovery.update_bridge_ip", fake_update_bridge_ip)
+
+    result = await ensure_bridge_reachable(config)
+
+    assert result == {"reachable": True, "configured": True, "bridge_ip": "192.168.x.y"}
+    assert updated["ip"] == "192.168.x.y"
+
+
+@respx.mock
+async def test_ensure_bridge_reachable_total_failure_returns_clean_status(monkeypatch):
+    config = BridgeConfig(bridge_ip="192.168.x.x", api_key="test-api-key")
+
+    respx.get(f"{BRIDGE_URL}/config").mock(
+        return_value=Response(200, json=[{"error": {"description": "unauthorized user"}}])
+    )
+
+    async def fake_rediscover(api_key):
+        return None
+
+    monkeypatch.setattr("app.bridge_discovery.load_config", lambda: config)
+    monkeypatch.setattr("app.bridge_discovery.rediscover_bridge_ip", fake_rediscover)
+
+    result = await ensure_bridge_reachable(config)
+
+    assert result == {"reachable": False, "configured": True, "bridge_ip": "192.168.x.x"}

--- a/backend/tests/test_health_route.py
+++ b/backend/tests/test_health_route.py
@@ -1,0 +1,49 @@
+from app.config import BridgeConfig
+
+
+async def test_health_reports_reachable_when_bridge_ok(client, monkeypatch):
+    async def fake_ensure_bridge_reachable(config):
+        return {"reachable": True, "configured": True, "bridge_ip": "192.168.x.x"}
+
+    monkeypatch.setattr("app.main.ensure_bridge_reachable", fake_ensure_bridge_reachable)
+
+    resp = await client.get("/api/health")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "status": "ok",
+        "reachable": True,
+        "configured": True,
+        "bridge_ip": "192.168.x.x",
+    }
+
+
+async def test_health_reports_unreachable_but_returns_200_when_repair_fails(client, monkeypatch):
+    async def fake_ensure_bridge_reachable(config):
+        return {"reachable": False, "configured": True, "bridge_ip": "192.168.x.x"}
+
+    monkeypatch.setattr("app.main.ensure_bridge_reachable", fake_ensure_bridge_reachable)
+
+    resp = await client.get("/api/health")
+
+    assert resp.status_code == 200
+    assert resp.json()["reachable"] is False
+
+
+async def test_health_not_configured(client, monkeypatch):
+    monkeypatch.setattr("app.main.load_config", lambda: BridgeConfig(bridge_ip=None, api_key=None))
+
+    async def fake_ensure_bridge_reachable(config):
+        return {"reachable": False, "configured": False, "bridge_ip": None}
+
+    monkeypatch.setattr("app.main.ensure_bridge_reachable", fake_ensure_bridge_reachable)
+
+    resp = await client.get("/api/health")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "status": "ok",
+        "reachable": False,
+        "configured": False,
+        "bridge_ip": None,
+    }

--- a/backend/tests/test_hue_client_write.py
+++ b/backend/tests/test_hue_client_write.py
@@ -74,7 +74,7 @@ async def test_status_error_skips_rediscovery(monkeypatch):
     async def fail_if_called(api_key):
         raise AssertionError("rediscovery should not run for a request-validation error")
 
-    monkeypatch.setattr("app.hue_client.rediscover_bridge_ip", fail_if_called)
+    monkeypatch.setattr("app.bridge_discovery.rediscover_bridge_ip", fail_if_called)
 
     respx.put(f"{BRIDGE_URL}/lights/1/state").mock(return_value=Response(400, json={"error": "bad request"}))
 
@@ -88,13 +88,13 @@ async def test_network_error_triggers_rediscovery(monkeypatch):
     # should still trigger the rediscovery/retry path.
     config = BridgeConfig(bridge_ip="192.168.x.x", api_key="test-api-key")
 
-    monkeypatch.setattr("app.hue_client.load_config", lambda: config)
-    monkeypatch.setattr("app.hue_client.update_bridge_ip", lambda ip: None)
+    monkeypatch.setattr("app.bridge_discovery.load_config", lambda: config)
+    monkeypatch.setattr("app.bridge_discovery.update_bridge_ip", lambda ip: None)
 
     async def fake_rediscover(api_key):
         return "192.168.x.y"
 
-    monkeypatch.setattr("app.hue_client.rediscover_bridge_ip", fake_rediscover)
+    monkeypatch.setattr("app.bridge_discovery.rediscover_bridge_ip", fake_rediscover)
 
     respx.put(f"{BRIDGE_URL}/lights/1/state").mock(side_effect=httpx.ConnectError("connection refused"))
     respx.put("http://192.168.x.y/api/test-api-key/lights/1/state").mock(
@@ -118,7 +118,7 @@ async def test_post_network_error_skips_rediscovery(monkeypatch):
     async def fail_if_called(api_key):
         raise AssertionError("rediscovery should not run for a POST network error")
 
-    monkeypatch.setattr("app.hue_client.rediscover_bridge_ip", fail_if_called)
+    monkeypatch.setattr("app.bridge_discovery.rediscover_bridge_ip", fail_if_called)
 
     respx.post(f"{BRIDGE_URL}/scenes").mock(side_effect=httpx.ConnectError("connection refused"))
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -233,7 +233,13 @@
     }
   }
 
-  onMount(() => {
+  onMount(async () => {
+    // Give a drifted bridge IP a chance to self-heal (see
+    // backend/app/bridge_discovery.py's ensure_bridge_reachable) before the
+    // panels below fire their own requests against a possibly-stale IP.
+    // The result isn't used directly — failures fall back to each panel's
+    // existing error + Retry UI.
+    await fetchJson('/api/health').catch(() => {})
     loadLights()
     loadScenes()
     loadZones()


### PR DESCRIPTION
## Summary
- Add `ensure_bridge_reachable()` in `bridge_discovery.py`, which verifies the configured `bridge_ip` and, if it doesn't verify as our bridge, rediscovers and persists the correct one (reusing the existing SSDP/N-UPnP discovery machinery) — without ever raising.
- `/api/health` now calls this proactively and returns `{status, configured, reachable, bridge_ip}` instead of just checking whether a bridge_ip is stored.
- `App.svelte`'s `onMount` awaits `/api/health` before firing the Bulbs/Scenes/Zones/Favorites/Themes loads, so a drifted IP self-heals before any panel makes its own request.
- Closes the gap where a stale IP belonging to some other live device (which answers with any HTTP response) never triggered rediscovery — only a genuine network-level failure did before this change.

Fixes #70

## Test plan
- [x] `pytest backend/tests` — 86 passed, including new `test_bridge_discovery.py` and `test_health_route.py`
- [x] `npm run build` in `frontend/` — succeeds
- [x] Manual: ran the backend against the real (stale) `config.yaml` bridge_ip; confirmed `/api/health` rediscovered and persisted the bridge's actual current IP, and `/api/lights` then returned real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VH1LNkHiwCbAN2jnzdh1C9