### PR TITLE
Write config.yaml in place instead of tempfile+rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ docs/
 .env.*
 !.env.example
 config.yaml
+config.yaml.recovery
 config.local.*
 
 # Python

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,5 +1,3 @@
-import os
-import tempfile
 import threading
 from pathlib import Path
 from typing import Optional
@@ -55,17 +53,17 @@ def load_config() -> BridgeConfig:
 
 
 def _write_config(config: BridgeConfig) -> None:
-    # Write-then-rename so a crash mid-write can't leave config.yaml
-    # truncated (which would also lose api_key, requiring re-pairing).
-    fd, tmp_path = tempfile.mkstemp(dir=CONFIG_PATH.parent, prefix=".config.yaml.")
-    try:
-        with os.fdopen(fd, "w") as f:
-            yaml.safe_dump(config.model_dump(exclude_none=True), f)
-        os.replace(tmp_path, CONFIG_PATH)
-    except BaseException:
-        if os.path.exists(tmp_path):
-            os.unlink(tmp_path)
-        raise
+    # In prod, config.yaml is bind-mounted into the container as a single
+    # file (see docker-compose.yml's `./backend/config.yaml:/app/config.yaml`),
+    # so its inode can't be atomically swapped via os.replace from inside the
+    # container -- that raises "OSError: [Errno 16] Device or resource busy"
+    # on the mount point. Write the file in place instead: build the full
+    # YAML content in memory first, so a serialization failure can't leave
+    # config.yaml half-written even though this no longer guards against a
+    # process kill mid-write.
+    content = yaml.safe_dump(config.model_dump(exclude_none=True))
+    with CONFIG_PATH.open("w") as f:
+        f.write(content)
 
 
 def update_bridge_ip(ip: str) -> None:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,13 +20,14 @@ def _recovery_path() -> Path:
     return CONFIG_PATH.parent / "config.yaml.recovery"
 
 
-# Serializes add_custom_theme's check-then-write against itself — FastAPI's
-# sync routes run in a threadpool, so two concurrent imports could otherwise
-# both read config.yaml before either writes, both pass a duplicate-id
-# check done outside this lock, and the second write would silently clobber
-# the first (each import_theme caller still getting a 201) rather than one
-# of them getting the intended 409.
-_themes_lock = threading.Lock()
+# Serializes every read-modify-write against config.yaml (originally just
+# add_custom_theme's check-then-write, e.g. two concurrent theme imports
+# both passing a duplicate-id check before either writes). Now guards every
+# writer, not just that one: _write_config writes config.yaml in place
+# (see its comment for why), which two overlapping writers could otherwise
+# interleave into corrupt, unparseable YAML -- unlike the old tempfile+
+# os.replace scheme, where the worst case was a benign lost update.
+_config_write_lock = threading.Lock()
 
 
 class DuplicateThemeError(Exception):
@@ -61,13 +62,18 @@ def load_config() -> BridgeConfig:
     if not CONFIG_PATH.exists():
         return BridgeConfig()
     with CONFIG_PATH.open() as f:
-        data = yaml.safe_load(f)
+        try:
+            data = yaml.safe_load(f)
+        except yaml.YAMLError:
+            # A crash mid-write (see _write_config) can leave config.yaml
+            # with new content followed by a leftover fragment of the old
+            # file's tail -- not just empty, but invalid YAML outright.
+            data = None
     if not data:
-        # config.yaml can end up empty if the process was killed at the
-        # exact wrong instant during _write_config's in-place write (see
-        # its comment) -- fall back to the last-known-good recovery copy
-        # rather than silently losing api_key, which would force physically
-        # re-pairing at the bridge.
+        # Also covers the plain-empty case (crash before any bytes were
+        # written) -- either way, fall back to the last-known-good recovery
+        # copy rather than silently losing api_key, which would force
+        # physically re-pairing at the bridge.
         data = _load_recovery_data()
     return BridgeConfig(**data)
 
@@ -112,19 +118,21 @@ def _write_config(config: BridgeConfig) -> None:
 
 
 def update_bridge_ip(ip: str) -> None:
-    config = load_config()
-    config.bridge_ip = ip
-    _write_config(config)
+    with _config_write_lock:
+        config = load_config()
+        config.bridge_ip = ip
+        _write_config(config)
 
 
 def update_favorite_scene_ids(scene_ids: list[str]) -> None:
-    config = load_config()
-    config.favorite_scene_ids = scene_ids
-    _write_config(config)
+    with _config_write_lock:
+        config = load_config()
+        config.favorite_scene_ids = scene_ids
+        _write_config(config)
 
 
 def add_custom_theme(theme: Theme) -> None:
-    with _themes_lock:
+    with _config_write_lock:
         config = load_config()
         if any(t.id == theme.id for t in config.custom_themes):
             raise DuplicateThemeError(theme.id)
@@ -133,6 +141,7 @@ def add_custom_theme(theme: Theme) -> None:
 
 
 def remove_custom_theme(theme_id: str) -> None:
-    config = load_config()
-    config.custom_themes = [t for t in config.custom_themes if t.id != theme_id]
-    _write_config(config)
+    with _config_write_lock:
+        config = load_config()
+        config.custom_themes = [t for t in config.custom_themes if t.id != theme_id]
+        _write_config(config)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import threading
 from pathlib import Path
 from typing import Optional
@@ -6,6 +8,17 @@ import yaml
 from pydantic import BaseModel
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.yaml"
+
+
+def _recovery_path() -> Path:
+    # A plain (non-bind-mounted) recovery copy of config.yaml's
+    # last-written content, used only as a fallback if config.yaml itself
+    # is ever found empty or unparseable -- see _write_config for why
+    # that's possible. Derived from CONFIG_PATH at call time (rather than
+    # a fixed module-level constant) so tests can retarget both by
+    # monkeypatching CONFIG_PATH alone.
+    return CONFIG_PATH.parent / "config.yaml.recovery"
+
 
 # Serializes add_custom_theme's check-then-write against itself — FastAPI's
 # sync routes run in a threadpool, so two concurrent imports could otherwise
@@ -48,22 +61,54 @@ def load_config() -> BridgeConfig:
     if not CONFIG_PATH.exists():
         return BridgeConfig()
     with CONFIG_PATH.open() as f:
-        data = yaml.safe_load(f) or {}
+        data = yaml.safe_load(f)
+    if not data:
+        # config.yaml can end up empty if the process was killed at the
+        # exact wrong instant during _write_config's in-place write (see
+        # its comment) -- fall back to the last-known-good recovery copy
+        # rather than silently losing api_key, which would force physically
+        # re-pairing at the bridge.
+        data = _load_recovery_data()
     return BridgeConfig(**data)
 
 
+def _load_recovery_data() -> dict:
+    recovery_path = _recovery_path()
+    if not recovery_path.exists():
+        return {}
+    with recovery_path.open() as f:
+        return yaml.safe_load(f) or {}
+
+
 def _write_config(config: BridgeConfig) -> None:
-    # In prod, config.yaml is bind-mounted into the container as a single
-    # file (see docker-compose.yml's `./backend/config.yaml:/app/config.yaml`),
-    # so its inode can't be atomically swapped via os.replace from inside the
-    # container -- that raises "OSError: [Errno 16] Device or resource busy"
-    # on the mount point. Write the file in place instead: build the full
-    # YAML content in memory first, so a serialization failure can't leave
-    # config.yaml half-written even though this no longer guards against a
-    # process kill mid-write.
     content = yaml.safe_dump(config.model_dump(exclude_none=True))
-    with CONFIG_PATH.open("w") as f:
+
+    # Stage a durable recovery copy first. Unlike config.yaml itself (see
+    # below), this path is an ordinary file in a normal directory, so a
+    # tempfile+os.replace here is a real atomic swap -- load_config falls
+    # back to it if the in-place write below is ever interrupted.
+    fd, tmp_path = tempfile.mkstemp(dir=CONFIG_PATH.parent, prefix=".config.yaml.")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp_path, _recovery_path())
+    except BaseException:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+    # config.yaml is bind-mounted into the container as a single file in
+    # prod (see docker-compose.yml's `./backend/config.yaml:/app/config.yaml`),
+    # so its inode can't be atomically swapped via os.replace from inside
+    # the container -- that raises "OSError: [Errno 16] Device or resource
+    # busy" on the mount point. Write in place instead, writing the full
+    # content before truncating so a crash here leaves the file at worst
+    # containing stale trailing bytes (recoverable via the recovery copy
+    # above), never an outright-empty file the way truncate-then-write would.
+    mode = "r+" if CONFIG_PATH.exists() else "w"
+    with CONFIG_PATH.open(mode) as f:
         f.write(content)
+        f.truncate()
 
 
 def update_bridge_ip(ip: str) -> None:

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -30,3 +30,40 @@ def test_update_bridge_ip_round_trips(tmp_path, monkeypatch):
     reloaded = load_config()
     assert reloaded.bridge_ip == "192.168.x.y"
     assert reloaded.api_key == "test-api-key"
+
+
+def test_write_config_leaves_a_recovery_copy(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("bridge_ip: 192.168.x.x\napi_key: test-api-key\n")
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+
+    update_bridge_ip("192.168.x.y")
+
+    recovery_path = tmp_path / "config.yaml.recovery"
+    assert recovery_path.exists()
+    assert "192.168.x.y" in recovery_path.read_text()
+
+
+def test_load_config_falls_back_to_recovery_when_config_yaml_is_empty(tmp_path, monkeypatch):
+    # Simulates the crash this fix targets: config.yaml left empty by an
+    # interrupted in-place write, with the recovery copy from the last
+    # successful write still intact.
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("")
+    (tmp_path / "config.yaml.recovery").write_text("bridge_ip: 192.168.x.x\napi_key: test-api-key\n")
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+
+    result = load_config()
+
+    assert result.bridge_ip == "192.168.x.x"
+    assert result.api_key == "test-api-key"
+
+
+def test_load_config_empty_with_no_recovery_copy_returns_defaults(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("")
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+
+    result = load_config()
+
+    assert result == BridgeConfig()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,32 @@
+import app.config as config_module
+from app.config import BridgeConfig, load_config, update_bridge_ip
+
+
+def test_write_config_preserves_inode(tmp_path, monkeypatch):
+    # Docker bind-mounts config.yaml into the container as a single file, so
+    # writing it must never replace the file's inode (e.g. via a
+    # tempfile+os.replace swap) -- that raises EBUSY against a bind-mounted
+    # target from inside the container. Pre-create the file (as the bind
+    # mount does) and confirm the same inode is still there afterward.
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("bridge_ip: 192.168.x.x\napi_key: test-api-key\n")
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+
+    original_inode = config_path.stat().st_ino
+
+    update_bridge_ip("192.168.x.y")
+
+    assert config_path.stat().st_ino == original_inode
+    assert load_config().bridge_ip == "192.168.x.y"
+
+
+def test_update_bridge_ip_round_trips(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("bridge_ip: 192.168.x.x\napi_key: test-api-key\n")
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+
+    update_bridge_ip("192.168.x.y")
+
+    reloaded = load_config()
+    assert reloaded.bridge_ip == "192.168.x.y"
+    assert reloaded.api_key == "test-api-key"

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -67,3 +67,20 @@ def test_load_config_empty_with_no_recovery_copy_returns_defaults(tmp_path, monk
     result = load_config()
 
     assert result == BridgeConfig()
+
+
+def test_load_config_falls_back_to_recovery_on_corrupt_yaml(tmp_path, monkeypatch):
+    # Simulates a crash in the write-before-truncate window when the new
+    # content is shorter than the old: config.yaml ends up as valid new
+    # content followed by a leftover fragment of the old file's tail,
+    # which is likely to fail to parse outright rather than just come back
+    # empty -- this must fall back to the recovery copy too, not 500.
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("bridge_ip: 192.168.x.y\n  - broken: [unterminated\n")
+    (tmp_path / "config.yaml.recovery").write_text("bridge_ip: 192.168.x.x\napi_key: test-api-key\n")
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+
+    result = load_config()
+
+    assert result.bridge_ip == "192.168.x.x"
+    assert result.api_key == "test-api-key"


### PR DESCRIPTION
## Summary
- `_write_config` in `backend/app/config.py` used to write via a tempfile + `os.replace` swap for crash-safety. In prod, `config.yaml` is a single-file Docker bind mount (`docker-compose.yml`), and its inode can't be replaced via rename from inside the container -- `os.replace` raised `OSError: [Errno 16] Device or resource busy`, discovered while deploying PR #71's proactive bridge rediscovery (the first write path to actually get exercised in prod).
- Same call also backs `update_favorite_scene_ids`/`add_custom_theme`/`remove_custom_theme`, so this was broken for any config write, not just bridge IP repair.
- Fix: build the YAML content in memory, then write directly into the existing file (no rename). Loses "crash-mid-write leaves it truncated" protection, kept the "bad serialization can't half-write the file" protection.

Fixes #72

## Test plan
- [x] `pytest backend/tests` -- 88 passed, including new `test_config.py` (`test_write_config_preserves_inode` asserts the file's inode is unchanged after a write, `test_update_bridge_ip_round_trips` covers the read-after-write path)
- [ ] Redeploy to MINIPC and confirm `/api/health` no longer 500s and repairs the real bridge IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VH1LNkHiwCbAN2jnzdh1C9