### PR TITLE
Add demo mode with mock bridge data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-backend dev-frontend pair-bridge
+.PHONY: dev dev-backend dev-frontend dev-demo dev-backend-demo pair-bridge
 
 dev-backend:
 	cd backend && . .venv/bin/activate && uvicorn app.main:app --reload --port 8000
@@ -9,6 +9,17 @@ dev-frontend:
 dev:
 	@trap 'kill 0' EXIT; \
 	$(MAKE) dev-backend & \
+	$(MAKE) dev-frontend & \
+	wait
+
+# Runs on in-memory fixture data instead of a real bridge -- no config.yaml
+# or bridge on the network needed. See backend/app/mock_hue_client.py.
+dev-backend-demo:
+	cd backend && . .venv/bin/activate && HUE_DEMO_MODE=true uvicorn app.main:app --reload --port 8000
+
+dev-demo:
+	@trap 'kill 0' EXIT; \
+	$(MAKE) dev-backend-demo & \
 	$(MAKE) dev-frontend & \
 	wait
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,43 +16,16 @@ from app.config import (
     remove_custom_theme,
     update_favorite_scene_ids,
 )
+from app import hue_client, mock_hue_client
 from app.hue_client import BridgeNotConfigured, BridgeUnreachable, Light, Scene, Zone
 
 # Runs entirely on in-memory fixture data instead of a real bridge -- lets
 # the app be run and demoed (e.g. for portfolio purposes) with no Hue
-# Bridge on the network. See app/mock_hue_client.py.
+# Bridge on the network. See app/mock_hue_client.py. A single module
+# reference (rather than two parallel import lists) keeps demo and real mode
+# structurally unable to drift apart when a function is added/renamed.
 DEMO_MODE = os.environ.get("HUE_DEMO_MODE", "").strip().lower() in ("1", "true", "yes")
-
-if DEMO_MODE:
-    from app.mock_hue_client import (
-        activate_scene,
-        create_scene,
-        get_group_light_ids,
-        get_lights,
-        get_scenes,
-        get_zones,
-        play_scene,
-        set_group_state,
-        set_light_state,
-        set_scene_speed,
-        set_zone_brightness_for_on_lights,
-        stop_scene,
-    )
-else:
-    from app.hue_client import (
-        activate_scene,
-        create_scene,
-        get_group_light_ids,
-        get_lights,
-        get_scenes,
-        get_zones,
-        play_scene,
-        set_group_state,
-        set_light_state,
-        set_scene_speed,
-        set_zone_brightness_for_on_lights,
-        stop_scene,
-    )
+_client = mock_hue_client if DEMO_MODE else hue_client
 
 app = FastAPI(title="Hue Light Control API")
 
@@ -89,7 +62,7 @@ async def health():
 @app.get("/api/lights")
 async def list_lights() -> list[Light]:
     config = load_config()
-    return await get_lights(config)
+    return await _client.get_lights(config)
 
 
 class LightStateUpdate(BaseModel):
@@ -111,7 +84,7 @@ async def update_light_state(light_id: str, update: LightStateUpdate):
     if update.on is None and update.brightness_pct is None and update.color is None and update.color_temp_pct is None:
         raise HTTPException(status_code=400, detail="must set on, brightness_pct, color, and/or color_temp_pct")
     config = load_config()
-    await set_light_state(
+    await _client.set_light_state(
         config,
         light_id,
         on=update.on,
@@ -125,13 +98,13 @@ async def update_light_state(light_id: str, update: LightStateUpdate):
 @app.get("/api/scenes")
 async def list_scenes() -> list[Scene]:
     config = load_config()
-    return await get_scenes(config)
+    return await _client.get_scenes(config)
 
 
 @app.get("/api/zones")
 async def list_zones() -> list[Zone]:
     config = load_config()
-    return await get_zones(config)
+    return await _client.get_zones(config)
 
 
 class SceneCreateRequest(BaseModel):
@@ -172,11 +145,11 @@ async def create_scene_route(body: SceneCreateRequest) -> Scene:
         # doesn't depend on the scene-creation result, so run both calls
         # concurrently instead of paying for two round-trips in series.
         scene_id, light_ids = await asyncio.gather(
-            create_scene(config, body.name, body.light_ids, body.group_id),
-            get_group_light_ids(config, body.group_id),
+            _client.create_scene(config, body.name, body.light_ids, body.group_id),
+            _client.get_group_light_ids(config, body.group_id),
         )
     else:
-        scene_id = await create_scene(config, body.name, body.light_ids, body.group_id)
+        scene_id = await _client.create_scene(config, body.name, body.light_ids, body.group_id)
         light_ids = body.light_ids
     return Scene(
         id=scene_id, name=body.name, light_count=len(light_ids), light_ids=light_ids, group_id=body.group_id
@@ -190,7 +163,7 @@ class SceneActivateRequest(BaseModel):
 @app.post("/api/scenes/{scene_id}/activate")
 async def activate_scene_route(scene_id: str, body: SceneActivateRequest):
     config = load_config()
-    await activate_scene(config, body.group_id, scene_id)
+    await _client.activate_scene(config, body.group_id, scene_id)
     return {"status": "ok"}
 
 
@@ -207,21 +180,21 @@ class SceneSpeedRequest(BaseModel):
 @app.post("/api/scenes/{scene_id}/play")
 async def play_scene_route(scene_id: str, body: ScenePlayRequest = ScenePlayRequest()):
     config = load_config()
-    await play_scene(config, scene_id, body.speed)
+    await _client.play_scene(config, scene_id, body.speed)
     return {"status": "ok"}
 
 
 @app.post("/api/scenes/{scene_id}/stop")
 async def stop_scene_route(scene_id: str):
     config = load_config()
-    await stop_scene(config, scene_id)
+    await _client.stop_scene(config, scene_id)
     return {"status": "ok"}
 
 
 @app.put("/api/scenes/{scene_id}/speed")
 async def set_scene_speed_route(scene_id: str, body: SceneSpeedRequest):
     config = load_config()
-    await set_scene_speed(config, scene_id, body.speed)
+    await _client.set_scene_speed(config, scene_id, body.speed)
     return {"status": "ok"}
 
 
@@ -288,9 +261,9 @@ async def update_zone_state(zone_id: str, update: ZoneStateUpdate):
         # Explicit on/off (the zone Off button, or the frontend's "drag up
         # from fully off" gesture) — applies to every light in the zone via
         # one group-action PUT, same as before.
-        await set_group_state(config, zone_id, on=update.on, brightness_pct=update.brightness_pct)
+        await _client.set_group_state(config, zone_id, on=update.on, brightness_pct=update.brightness_pct)
     else:
         # A plain brightness drag on an already-partially-on zone shouldn't
         # wake up bulbs the user individually turned off.
-        await set_zone_brightness_for_on_lights(config, zone_id, update.brightness_pct)
+        await _client.set_zone_brightness_for_on_lights(config, zone_id, update.brightness_pct)
     return {"status": "ok"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,25 +16,43 @@ from app.config import (
     remove_custom_theme,
     update_favorite_scene_ids,
 )
-from app.hue_client import (
-    BridgeNotConfigured,
-    BridgeUnreachable,
-    Light,
-    Scene,
-    Zone,
-    activate_scene,
-    create_scene,
-    get_group_light_ids,
-    get_lights,
-    get_scenes,
-    get_zones,
-    play_scene,
-    set_group_state,
-    set_light_state,
-    set_scene_speed,
-    set_zone_brightness_for_on_lights,
-    stop_scene,
-)
+from app.hue_client import BridgeNotConfigured, BridgeUnreachable, Light, Scene, Zone
+
+# Runs entirely on in-memory fixture data instead of a real bridge -- lets
+# the app be run and demoed (e.g. for portfolio purposes) with no Hue
+# Bridge on the network. See app/mock_hue_client.py.
+DEMO_MODE = os.environ.get("HUE_DEMO_MODE", "").strip().lower() in ("1", "true", "yes")
+
+if DEMO_MODE:
+    from app.mock_hue_client import (
+        activate_scene,
+        create_scene,
+        get_group_light_ids,
+        get_lights,
+        get_scenes,
+        get_zones,
+        play_scene,
+        set_group_state,
+        set_light_state,
+        set_scene_speed,
+        set_zone_brightness_for_on_lights,
+        stop_scene,
+    )
+else:
+    from app.hue_client import (
+        activate_scene,
+        create_scene,
+        get_group_light_ids,
+        get_lights,
+        get_scenes,
+        get_zones,
+        play_scene,
+        set_group_state,
+        set_light_state,
+        set_scene_speed,
+        set_zone_brightness_for_on_lights,
+        stop_scene,
+    )
 
 app = FastAPI(title="Hue Light Control API")
 
@@ -61,6 +79,8 @@ async def bridge_unreachable_handler(request: Request, exc: BridgeUnreachable) -
 
 @app.get("/api/health")
 async def health():
+    if DEMO_MODE:
+        return {"status": "ok", "reachable": True, "configured": True, "bridge_ip": "demo"}
     config = load_config()
     status = await ensure_bridge_reachable(config)
     return {"status": "ok", **status}

--- a/backend/app/mock_hue_client.py
+++ b/backend/app/mock_hue_client.py
@@ -17,7 +17,7 @@ a demo.
 
 from typing import Optional
 
-from app.hue_client import Light, Scene, Zone
+from app.hue_client import BridgeUnreachable, Light, Scene, Zone
 
 _lights: dict[str, Light] = {
     # Living Room: Extended color
@@ -47,6 +47,7 @@ _zones: dict[str, Zone] = {
     "3": Zone(id="3", name="Kitchen", light_count=3, light_ids=["7", "8", "9"]),
     "4": Zone(id="4", name="Hallway", light_count=2, light_ids=["10", "11"]),
     "5": Zone(id="5", name="Office", light_count=1, light_ids=["13"]),
+    "6": Zone(id="6", name="Closet", light_count=1, light_ids=["12"]),
 }
 
 _scenes: dict[str, Scene] = {
@@ -98,6 +99,8 @@ async def get_zones(config) -> list[Zone]:
 
 async def create_scene(config, name: str, light_ids: list[str], group_id: Optional[str] = None) -> str:
     global _next_scene_id
+    if group_id is not None and group_id not in _zones:
+        raise BridgeUnreachable(f"zone {group_id} does not exist")
     scene_id = str(_next_scene_id)
     _next_scene_id += 1
     resolved_light_ids = _zones[group_id].light_ids if group_id is not None else light_ids

--- a/backend/app/mock_hue_client.py
+++ b/backend/app/mock_hue_client.py
@@ -1,0 +1,170 @@
+"""In-memory stand-in for hue_client.py, used when HUE_DEMO_MODE is set (see
+main.py). Lets the app run and be demoed -- e.g. for portfolio purposes --
+with no real Hue Bridge on the network.
+
+Fixture shape (light type mix, zone layout) mirrors a real bridge's
+docs/hue-bridge-catalog.md (6x Dimmable, 6x Extended color, 1x Color
+temperature), not any invented arrangement, so the demo represents an
+actual owned setup. All names/rooms below are generic, not this app's real
+room names.
+
+Every function here matches the signature of its hue_client.py counterpart
+so main.py's route bodies are unaware which one they're calling. State
+lives in module-level dicts, seeded fresh on import and mutated in place by
+writes -- resets to the fixture on every process restart, which is fine for
+a demo.
+"""
+
+from typing import Optional
+
+from app.hue_client import Light, Scene, Zone
+
+_lights: dict[str, Light] = {
+    # Living Room: Extended color
+    "1": Light(id="1", name="Living Room Lamp", on=True, brightness_pct=80, color="#ffb366", supports_color=True, supports_color_temp=True, reachable=True),
+    "2": Light(id="2", name="Living Room Floor", on=True, brightness_pct=65, color="#ffb366", supports_color=True, supports_color_temp=True, reachable=True),
+    "3": Light(id="3", name="Living Room Accent", on=False, brightness_pct=50, color="#7fd4ff", supports_color=True, supports_color_temp=True, reachable=True),
+    # Bedroom: Extended color
+    "4": Light(id="4", name="Bedroom Nightstand Left", on=False, brightness_pct=30, color="#ff8080", supports_color=True, supports_color_temp=True, reachable=True),
+    "5": Light(id="5", name="Bedroom Nightstand Right", on=False, brightness_pct=30, color="#ff8080", supports_color=True, supports_color_temp=True, reachable=True),
+    "6": Light(id="6", name="Bedroom Ceiling", on=True, brightness_pct=45, color="#fff2cc", supports_color=True, supports_color_temp=True, reachable=True),
+    # Kitchen: Dimmable
+    "7": Light(id="7", name="Kitchen Under-Cabinet 1", on=True, brightness_pct=100, supports_color=False, supports_color_temp=False, reachable=True),
+    "8": Light(id="8", name="Kitchen Under-Cabinet 2", on=True, brightness_pct=100, supports_color=False, supports_color_temp=False, reachable=True),
+    "9": Light(id="9", name="Kitchen Island", on=True, brightness_pct=90, supports_color=False, supports_color_temp=False, reachable=True),
+    # Hallway: Dimmable
+    "10": Light(id="10", name="Hallway Sconce 1", on=False, brightness_pct=40, supports_color=False, supports_color_temp=False, reachable=True),
+    "11": Light(id="11", name="Hallway Sconce 2", on=False, brightness_pct=40, supports_color=False, supports_color_temp=False, reachable=True),
+    # Closet: Dimmable
+    "12": Light(id="12", name="Closet", on=False, brightness_pct=100, supports_color=False, supports_color_temp=False, reachable=True),
+    # Office: Color temperature
+    "13": Light(id="13", name="Office Desk Lamp", on=True, brightness_pct=70, color_temp_pct=60, supports_color=False, supports_color_temp=True, reachable=True),
+}
+
+_zones: dict[str, Zone] = {
+    "1": Zone(id="1", name="Living Room", light_count=3, light_ids=["1", "2", "3"]),
+    "2": Zone(id="2", name="Bedroom", light_count=3, light_ids=["4", "5", "6"]),
+    "3": Zone(id="3", name="Kitchen", light_count=3, light_ids=["7", "8", "9"]),
+    "4": Zone(id="4", name="Hallway", light_count=2, light_ids=["10", "11"]),
+    "5": Zone(id="5", name="Office", light_count=1, light_ids=["13"]),
+}
+
+_scenes: dict[str, Scene] = {
+    "1": Scene(id="1", name="Relax", light_count=3, light_ids=["1", "2", "3"], group_id="1", playing=False, speed=0.5),
+    "2": Scene(id="2", name="Movie Night", light_count=3, light_ids=["1", "2", "3"], group_id="1", playing=False, speed=0.3),
+    "3": Scene(id="3", name="Bright", light_count=3, light_ids=["4", "5", "6"], group_id="2", playing=False, speed=0.5),
+    "4": Scene(id="4", name="Wind Down", light_count=3, light_ids=["4", "5", "6"], group_id="2", playing=True, speed=0.4),
+    "5": Scene(id="5", name="Cooking", light_count=3, light_ids=["7", "8", "9"], group_id="3", playing=False, speed=0.5),
+}
+
+_next_scene_id = 6
+
+
+async def get_lights(config) -> list[Light]:
+    return list(_lights.values())
+
+
+async def set_light_state(
+    config,
+    light_id: str,
+    *,
+    on: Optional[bool] = None,
+    brightness_pct: Optional[int] = None,
+    color: Optional[str] = None,
+    color_temp_pct: Optional[int] = None,
+) -> None:
+    light = _lights.get(light_id)
+    if light is None:
+        return
+    updates = {}
+    if on is not None:
+        updates["on"] = on
+    if brightness_pct is not None:
+        updates["brightness_pct"] = brightness_pct
+    if color is not None:
+        updates["color"] = color
+    if color_temp_pct is not None:
+        updates["color_temp_pct"] = color_temp_pct
+    _lights[light_id] = light.model_copy(update=updates)
+
+
+async def get_scenes(config) -> list[Scene]:
+    return list(_scenes.values())
+
+
+async def get_zones(config) -> list[Zone]:
+    return list(_zones.values())
+
+
+async def create_scene(config, name: str, light_ids: list[str], group_id: Optional[str] = None) -> str:
+    global _next_scene_id
+    scene_id = str(_next_scene_id)
+    _next_scene_id += 1
+    resolved_light_ids = _zones[group_id].light_ids if group_id is not None else light_ids
+    _scenes[scene_id] = Scene(
+        id=scene_id,
+        name=name,
+        light_count=len(resolved_light_ids),
+        light_ids=resolved_light_ids,
+        group_id=group_id,
+    )
+    return scene_id
+
+
+async def activate_scene(config, group_id: str, scene_id: str) -> None:
+    scene = _scenes.get(scene_id)
+    if scene is None:
+        return
+    for light_id in scene.light_ids:
+        light = _lights.get(light_id)
+        if light is not None:
+            _lights[light_id] = light.model_copy(update={"on": True})
+
+
+async def play_scene(config, scene_id: str, speed: float) -> None:
+    scene = _scenes.get(scene_id)
+    if scene is not None:
+        _scenes[scene_id] = scene.model_copy(update={"playing": True, "speed": speed})
+
+
+async def stop_scene(config, scene_id: str) -> None:
+    scene = _scenes.get(scene_id)
+    if scene is not None:
+        _scenes[scene_id] = scene.model_copy(update={"playing": False})
+
+
+async def set_scene_speed(config, scene_id: str, speed: float) -> None:
+    scene = _scenes.get(scene_id)
+    if scene is not None:
+        _scenes[scene_id] = scene.model_copy(update={"speed": speed})
+
+
+async def get_group_light_ids(config, group_id: str) -> list[str]:
+    zone = _zones.get(group_id)
+    return zone.light_ids if zone else []
+
+
+async def set_group_state(config, group_id: str, *, on: Optional[bool] = None, brightness_pct: Optional[int] = None) -> None:
+    zone = _zones.get(group_id)
+    if zone is None:
+        return
+    for light_id in zone.light_ids:
+        light = _lights.get(light_id)
+        if light is None:
+            continue
+        updates = {}
+        if on is not None:
+            updates["on"] = on
+        if brightness_pct is not None:
+            updates["brightness_pct"] = brightness_pct
+        _lights[light_id] = light.model_copy(update=updates)
+
+
+async def set_zone_brightness_for_on_lights(config, group_id: str, brightness_pct: int) -> None:
+    zone = _zones.get(group_id)
+    if zone is None:
+        return
+    for light_id in zone.light_ids:
+        light = _lights.get(light_id)
+        if light is not None and light.on:
+            _lights[light_id] = light.model_copy(update={"brightness_pct": brightness_pct})

--- a/backend/tests/test_demo_mode.py
+++ b/backend/tests/test_demo_mode.py
@@ -1,0 +1,70 @@
+import importlib
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+async def demo_client(monkeypatch):
+    monkeypatch.setenv("HUE_DEMO_MODE", "true")
+    import app.mock_hue_client as mock_hue_client
+    import app.main as main
+
+    importlib.reload(mock_hue_client)
+    importlib.reload(main)
+    transport = ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    monkeypatch.delenv("HUE_DEMO_MODE", raising=False)
+    importlib.reload(mock_hue_client)
+    importlib.reload(main)
+
+
+async def test_demo_health_reports_reachable_with_no_config(demo_client):
+    resp = await demo_client.get("/api/health")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "reachable": True, "configured": True, "bridge_ip": "demo"}
+
+
+async def test_demo_lights_have_fixture_data(demo_client):
+    resp = await demo_client.get("/api/lights")
+
+    assert resp.status_code == 200
+    lights = resp.json()
+    assert len(lights) == 13
+    assert sum(1 for light in lights if light["supports_color"]) == 6
+    assert sum(1 for light in lights if light["supports_color_temp"] and not light["supports_color"]) == 1
+    assert sum(1 for light in lights if not light["supports_color"] and not light["supports_color_temp"]) == 6
+
+
+async def test_demo_zones_and_scenes_have_fixture_data(demo_client):
+    zones_resp = await demo_client.get("/api/zones")
+    scenes_resp = await demo_client.get("/api/scenes")
+
+    assert zones_resp.status_code == 200
+    assert scenes_resp.status_code == 200
+    assert len(zones_resp.json()) == 5
+    assert len(scenes_resp.json()) == 5
+
+
+async def test_demo_set_light_state_persists_in_memory(demo_client):
+    resp = await demo_client.put("/api/lights/1/state", json={"on": False, "brightness_pct": 10})
+    assert resp.status_code == 200
+
+    lights = (await demo_client.get("/api/lights")).json()
+    light = next(l for l in lights if l["id"] == "1")
+    assert light["on"] is False
+    assert light["brightness_pct"] == 10
+
+
+async def test_demo_create_scene(demo_client):
+    resp = await demo_client.post(
+        "/api/scenes", json={"name": "Demo Scene", "light_ids": ["1", "2"], "group_id": None}
+    )
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["name"] == "Demo Scene"
+    assert body["light_ids"] == ["1", "2"]

--- a/backend/tests/test_demo_mode.py
+++ b/backend/tests/test_demo_mode.py
@@ -1,24 +1,33 @@
-import importlib
-
 import pytest
 from httpx import ASGITransport, AsyncClient
+
+from app import mock_hue_client
+
+
+@pytest.fixture(autouse=True)
+def _reset_mock_fixture_state(monkeypatch):
+    # mock_hue_client's dicts are mutated in place by writes -- reset each
+    # test to the fixture's own snapshot rather than leaking mutations
+    # (or _next_scene_id increments) across tests.
+    monkeypatch.setattr(mock_hue_client, "_lights", dict(mock_hue_client._lights))
+    monkeypatch.setattr(mock_hue_client, "_scenes", dict(mock_hue_client._scenes))
+    monkeypatch.setattr(mock_hue_client, "_next_scene_id", mock_hue_client._next_scene_id)
 
 
 @pytest.fixture
 async def demo_client(monkeypatch):
-    monkeypatch.setenv("HUE_DEMO_MODE", "true")
-    import app.mock_hue_client as mock_hue_client
-    import app.main as main
+    # Route app.main's routes at the mock client without reimporting/
+    # reloading app.main -- that would rebind the module's shared __dict__
+    # out from under the real FastAPI app instance other tests already hold
+    # a reference to (see app.main._client's docstring).
+    monkeypatch.setattr("app.main._client", mock_hue_client)
+    monkeypatch.setattr("app.main.DEMO_MODE", True)
 
-    importlib.reload(mock_hue_client)
-    importlib.reload(main)
-    transport = ASGITransport(app=main.app)
+    from app.main import app
+
+    transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
-
-    monkeypatch.delenv("HUE_DEMO_MODE", raising=False)
-    importlib.reload(mock_hue_client)
-    importlib.reload(main)
 
 
 async def test_demo_health_reports_reachable_with_no_config(demo_client):
@@ -45,8 +54,14 @@ async def test_demo_zones_and_scenes_have_fixture_data(demo_client):
 
     assert zones_resp.status_code == 200
     assert scenes_resp.status_code == 200
-    assert len(zones_resp.json()) == 5
+    zones = zones_resp.json()
+    assert len(zones) == 6
     assert len(scenes_resp.json()) == 5
+
+    # Every light belongs to exactly one zone -- no light left stranded
+    # outside the zone-based UI (frontend groups lights strictly by zone).
+    zoned_light_ids = {light_id for zone in zones for light_id in zone["light_ids"]}
+    assert zoned_light_ids == set(mock_hue_client._lights.keys())
 
 
 async def test_demo_set_light_state_persists_in_memory(demo_client):
@@ -68,3 +83,11 @@ async def test_demo_create_scene(demo_client):
     body = resp.json()
     assert body["name"] == "Demo Scene"
     assert body["light_ids"] == ["1", "2"]
+
+
+async def test_demo_create_scene_with_unknown_group_returns_502(demo_client):
+    resp = await demo_client.post(
+        "/api/scenes", json={"name": "Demo Scene", "light_ids": [], "group_id": "99"}
+    )
+
+    assert resp.status_code == 502


### PR DESCRIPTION
## Summary
- Adds `HUE_DEMO_MODE` env var (`make dev-demo` for convenience) that swaps the real `hue_client` for a new in-memory `mock_hue_client`, so the app runs and can be demoed with no Hue Bridge on the network.
- Fixture data (13 lights, 5 zones, 5 scenes) is shaped after this app's real bridge (6 dimmable, 6 extended-color, 1 color-temp — see `docs/hue-bridge-catalog.md`), not invented, so the demo represents an actual owned setup without any real identifiers.
- `/api/health` returns a canned "reachable" status in demo mode instead of running real bridge discovery.

Closes #6.

## Test plan
- [x] Full backend test suite passes (97 tests, including 5 new demo-mode tests)
- [x] Manually started backend (`HUE_DEMO_MODE=true`) + frontend dev servers and verified `/api/health`, `/api/lights`, `/api/zones`, `/api/scenes` all return fixture data
- [x] Verified in-browser: bulbs, zones, and per-zone scenes render correctly against the mock backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4bft55QLZDDpqtyPhJ4Fk