### PR TITLE
Mount config.yaml's parent directory instead of the file itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ docs/
 .env.*
 !.env.example
 config.yaml
-config.yaml.recovery
 config.local.*
 
 # Python

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -2,5 +2,5 @@ __pycache__/
 *.pyc
 .venv/
 venv/
-config.yaml
+data/
 .env

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -7,26 +7,19 @@ from typing import Optional
 import yaml
 from pydantic import BaseModel
 
-CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.yaml"
-
-
-def _recovery_path() -> Path:
-    # A plain (non-bind-mounted) recovery copy of config.yaml's
-    # last-written content, used only as a fallback if config.yaml itself
-    # is ever found empty or unparseable -- see _write_config for why
-    # that's possible. Derived from CONFIG_PATH at call time (rather than
-    # a fixed module-level constant) so tests can retarget both by
-    # monkeypatching CONFIG_PATH alone.
-    return CONFIG_PATH.parent / "config.yaml.recovery"
-
+# Lives in its own directory (rather than directly under backend/) so that
+# directory, not the single file, is what gets bind-mounted into the
+# container in prod (see docker-compose.yml) -- letting _write_config's
+# tempfile+os.replace do a real atomic swap from inside the container.
+# Mounting the single file instead makes os.replace's inode swap raise
+# "OSError: [Errno 16] Device or resource busy" against the mount point
+# (see issue #74) -- this was tried and reverted (#73).
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "data" / "config.yaml"
 
 # Serializes every read-modify-write against config.yaml (originally just
 # add_custom_theme's check-then-write, e.g. two concurrent theme imports
-# both passing a duplicate-id check before either writes). Now guards every
-# writer, not just that one: _write_config writes config.yaml in place
-# (see its comment for why), which two overlapping writers could otherwise
-# interleave into corrupt, unparseable YAML -- unlike the old tempfile+
-# os.replace scheme, where the worst case was a benign lost update.
+# both passing a duplicate-id check before either writes, then both writing
+# -- the second write silently clobbering the first's).
 _config_write_lock = threading.Lock()
 
 
@@ -62,59 +55,28 @@ def load_config() -> BridgeConfig:
     if not CONFIG_PATH.exists():
         return BridgeConfig()
     with CONFIG_PATH.open() as f:
-        try:
-            data = yaml.safe_load(f)
-        except yaml.YAMLError:
-            # A crash mid-write (see _write_config) can leave config.yaml
-            # with new content followed by a leftover fragment of the old
-            # file's tail -- not just empty, but invalid YAML outright.
-            data = None
-    if not data:
-        # Also covers the plain-empty case (crash before any bytes were
-        # written) -- either way, fall back to the last-known-good recovery
-        # copy rather than silently losing api_key, which would force
-        # physically re-pairing at the bridge.
-        data = _load_recovery_data()
+        data = yaml.safe_load(f) or {}
     return BridgeConfig(**data)
 
 
-def _load_recovery_data() -> dict:
-    recovery_path = _recovery_path()
-    if not recovery_path.exists():
-        return {}
-    with recovery_path.open() as f:
-        return yaml.safe_load(f) or {}
-
-
 def _write_config(config: BridgeConfig) -> None:
-    content = yaml.safe_dump(config.model_dump(exclude_none=True))
-
-    # Stage a durable recovery copy first. Unlike config.yaml itself (see
-    # below), this path is an ordinary file in a normal directory, so a
-    # tempfile+os.replace here is a real atomic swap -- load_config falls
-    # back to it if the in-place write below is ever interrupted.
+    # Write-then-rename so a crash mid-write can't leave config.yaml
+    # truncated (which would also lose api_key, requiring re-pairing).
+    # Safe to do here (unlike writing CONFIG_PATH directly when it was
+    # itself the bind-mount target, see CONFIG_PATH's comment) because the
+    # bind mount is now CONFIG_PATH's parent directory, not CONFIG_PATH
+    # itself -- os.replace only needs to swap an inode within that
+    # directory, not across the mount boundary.
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(dir=CONFIG_PATH.parent, prefix=".config.yaml.")
     try:
         with os.fdopen(fd, "w") as f:
-            f.write(content)
-        os.replace(tmp_path, _recovery_path())
+            yaml.safe_dump(config.model_dump(exclude_none=True), f)
+        os.replace(tmp_path, CONFIG_PATH)
     except BaseException:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
         raise
-
-    # config.yaml is bind-mounted into the container as a single file in
-    # prod (see docker-compose.yml's `./backend/config.yaml:/app/config.yaml`),
-    # so its inode can't be atomically swapped via os.replace from inside
-    # the container -- that raises "OSError: [Errno 16] Device or resource
-    # busy" on the mount point. Write in place instead, writing the full
-    # content before truncating so a crash here leaves the file at worst
-    # containing stale trailing bytes (recoverable via the recovery copy
-    # above), never an outright-empty file the way truncate-then-write would.
-    mode = "r+" if CONFIG_PATH.exists() else "w"
-    with CONFIG_PATH.open(mode) as f:
-        f.write(content)
-        f.truncate()
 
 
 def update_bridge_ip(ip: str) -> None:

--- a/backend/scripts/pair_bridge.py
+++ b/backend/scripts/pair_bridge.py
@@ -85,6 +85,7 @@ def write_config(ip: str, api_key: str) -> None:
         with CONFIG_PATH.open() as f:
             existing = yaml.safe_load(f) or {}
     existing.update({"bridge_ip": ip, "api_key": api_key})
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     with CONFIG_PATH.open("w") as f:
         yaml.safe_dump(existing, f)
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -2,24 +2,6 @@ import app.config as config_module
 from app.config import BridgeConfig, load_config, update_bridge_ip
 
 
-def test_write_config_preserves_inode(tmp_path, monkeypatch):
-    # Docker bind-mounts config.yaml into the container as a single file, so
-    # writing it must never replace the file's inode (e.g. via a
-    # tempfile+os.replace swap) -- that raises EBUSY against a bind-mounted
-    # target from inside the container. Pre-create the file (as the bind
-    # mount does) and confirm the same inode is still there afterward.
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text("bridge_ip: 192.168.x.x\napi_key: test-api-key\n")
-    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
-
-    original_inode = config_path.stat().st_ino
-
-    update_bridge_ip("192.168.x.y")
-
-    assert config_path.stat().st_ino == original_inode
-    assert load_config().bridge_ip == "192.168.x.y"
-
-
 def test_update_bridge_ip_round_trips(tmp_path, monkeypatch):
     config_path = tmp_path / "config.yaml"
     config_path.write_text("bridge_ip: 192.168.x.x\napi_key: test-api-key\n")
@@ -32,55 +14,43 @@ def test_update_bridge_ip_round_trips(tmp_path, monkeypatch):
     assert reloaded.api_key == "test-api-key"
 
 
-def test_write_config_leaves_a_recovery_copy(tmp_path, monkeypatch):
+def test_write_config_swaps_the_inode(tmp_path, monkeypatch):
+    # The directory (not config.yaml itself) is what's bind-mounted into
+    # the container in prod (see docker-compose.yml) -- confirms writes go
+    # through a real tempfile+os.replace atomic swap rather than an
+    # in-place write, which would raise EBUSY against a single-file mount
+    # but is unnecessary (and was reverted, see #74) now that only the
+    # parent directory crosses the mount boundary.
     config_path = tmp_path / "config.yaml"
     config_path.write_text("bridge_ip: 192.168.x.x\napi_key: test-api-key\n")
     monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
 
+    original_inode = config_path.stat().st_ino
+
     update_bridge_ip("192.168.x.y")
 
-    recovery_path = tmp_path / "config.yaml.recovery"
-    assert recovery_path.exists()
-    assert "192.168.x.y" in recovery_path.read_text()
+    assert config_path.stat().st_ino != original_inode
 
 
-def test_load_config_falls_back_to_recovery_when_config_yaml_is_empty(tmp_path, monkeypatch):
-    # Simulates the crash this fix targets: config.yaml left empty by an
-    # interrupted in-place write, with the recovery copy from the last
-    # successful write still intact.
+def test_write_config_creates_parent_directory(tmp_path, monkeypatch):
+    config_path = tmp_path / "data" / "config.yaml"
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+
+    update_bridge_ip("192.168.x.y")
+
+    assert load_config().bridge_ip == "192.168.x.y"
+
+
+def test_load_config_missing_file_returns_defaults(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+
+    assert load_config() == BridgeConfig()
+
+
+def test_load_config_empty_file_returns_defaults(tmp_path, monkeypatch):
     config_path = tmp_path / "config.yaml"
     config_path.write_text("")
-    (tmp_path / "config.yaml.recovery").write_text("bridge_ip: 192.168.x.x\napi_key: test-api-key\n")
     monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
 
-    result = load_config()
-
-    assert result.bridge_ip == "192.168.x.x"
-    assert result.api_key == "test-api-key"
-
-
-def test_load_config_empty_with_no_recovery_copy_returns_defaults(tmp_path, monkeypatch):
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text("")
-    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
-
-    result = load_config()
-
-    assert result == BridgeConfig()
-
-
-def test_load_config_falls_back_to_recovery_on_corrupt_yaml(tmp_path, monkeypatch):
-    # Simulates a crash in the write-before-truncate window when the new
-    # content is shorter than the old: config.yaml ends up as valid new
-    # content followed by a leftover fragment of the old file's tail,
-    # which is likely to fail to parse outright rather than just come back
-    # empty -- this must fall back to the recovery copy too, not 500.
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text("bridge_ip: 192.168.x.y\n  - broken: [unterminated\n")
-    (tmp_path / "config.yaml.recovery").write_text("bridge_ip: 192.168.x.x\napi_key: test-api-key\n")
-    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
-
-    result = load_config()
-
-    assert result.bridge_ip == "192.168.x.x"
-    assert result.api_key == "test-api-key"
+    assert load_config() == BridgeConfig()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,7 @@ services:
     environment:
       CORS_ORIGIN: "${CORS_ORIGIN:-http://localhost:5173}"
     volumes:
-      - ./backend/config.yaml:/app/config.yaml
+      # A directory mount, not a single-file mount -- lets config.py's
+      # tempfile+os.replace do a real atomic swap from inside the container
+      # (a single-file bind mount can't have its inode replaced; see #74).
+      - ./backend/data:/app/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # over 127.0.0.1 without publishing/mapping a port.
     network_mode: host
     # CORS_ORIGIN is supplied by a .env file placed by hand on the deploy
-    # target (same treatment as backend/config.yaml — never synced by
+    # target (same treatment as backend/data/config.yaml — never synced by
     # deploy.sh, never committed, since it contains the real LAN address).
     # Falls back to the Vite dev origin so `docker compose up` still works
     # locally without one.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,8 +10,9 @@
 #   - REMOTE_STATIC_DIR set to the nginx-served static directory, e.g.:
 #       export REMOTE_STATIC_DIR=/opt/webapps/hueLightControl
 #   - One-time manual setup already done on MINIPC: those directories
-#     created, backend/config.yaml placed at $REMOTE_DIR/backend/config.yaml,
-#     a .env placed at $REMOTE_DIR/.env with the real CORS_ORIGIN (both
+#     created, backend/data/config.yaml placed at
+#     $REMOTE_DIR/backend/data/config.yaml, a .env placed at
+#     $REMOTE_DIR/.env with the real CORS_ORIGIN (both
 #     scp'd by hand — never by this script, which only ever syncs
 #     docker-compose.yml itself, not the directory it lives in), and
 #     nginx.conf wired up. See docs/deploy.md.


### PR DESCRIPTION
## Summary
- Root-cause fix for #74: the prod bind mount targeted `config.yaml` directly, so its inode couldn't be atomically swapped from inside the container (`os.replace` raised EBUSY). #73 worked around this with an in-place write + recovery-copy fallback, but that only self-heals on the next write, not across a redeploy (the container's writable layer, where the recovery copy lived, gets wiped).
- Mounts the containing directory instead (`./backend/data:/app/data`), so `config.py` can revert to the simpler tempfile+`os.replace` design from before #73 — no recovery-copy machinery needed at all.
- `CONFIG_PATH` moves to `backend/data/config.yaml`. `_write_config` and `pair_bridge.py` both create the parent directory if missing.

Closes #74.

## Test plan
- [x] Full backend test suite passes (97 tests) — replaced the old inode-preservation test (which asserted the in-place-write behavior we're reverting) with one asserting the inode *does* swap, plus a parent-directory-creation test.
- [x] `docs/deploy.md` has the one-time migration step for the already-deployed MINIPC instance (move its existing `backend/config.yaml` into `backend/data/config.yaml` before the first deploy of this fix) — will run that by hand before deploying this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4bft55QLZDDpqtyPhJ4Fk